### PR TITLE
feat: add `prod-jenkins-public-vnet-apptier` Network Security Group

### DIFF
--- a/nsg.tf
+++ b/nsg.tf
@@ -1,0 +1,94 @@
+## Network Security Groups
+resource "azurerm_network_security_group" "prod_public_apptier" {
+  name                = "prod-jenkins-public-vnet-apptier"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.prod_public.name
+
+  # Inbound rules
+  security_rule {
+    name                   = "allow-http-inbound"
+    priority               = 100
+    direction              = "Inbound"
+    access                 = "Allow"
+    protocol               = "Tcp"
+    source_port_range      = "*"
+    destination_port_range = "80"
+  }
+  security_rule {
+    name                   = "allow-https-inbound"
+    priority               = 101
+    direction              = "Inbound"
+    access                 = "Allow"
+    protocol               = "Tcp"
+    source_port_range      = "*"
+    destination_port_range = "443"
+  }
+  security_rule {
+    name                   = "allow-ldap-inbound"
+    priority               = 102
+    direction              = "Inbound"
+    access                 = "Allow"
+    protocol               = "Tcp"
+    source_port_range      = "*"
+    destination_port_range = "636"
+  }
+  security_rule {
+    name                       = "allow-rsyncd-inbound"
+    priority                   = 103
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "873"
+    source_address_prefixes    = var.whitelist_ips
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "allow-public-ssh-inbound"
+    priority                   = 4000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefixes    = azurerm_virtual_network.prod_public.address_space
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "allow-private-ssh-inbound"
+    priority                   = 4001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefixes    = azurerm_virtual_network.prod_private.address_space
+    destination_address_prefix = "*"
+  }
+
+  # Outbound rules
+  security_rule {
+    name                         = "allow-puppet-outbound"
+    priority                     = 2100
+    direction                    = "Outbound"
+    access                       = "Allow"
+    protocol                     = "Tcp"
+    source_port_range            = "8140"
+    destination_port_range       = "*"
+    source_address_prefix        = "*"
+    destination_address_prefixes = azurerm_virtual_network.prod_private.address_space
+  }
+  security_rule {
+    name                       = "allow-https-outbound"
+    priority                   = 2101
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "443"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  tags = local.default_tags
+}

--- a/nsg.tf
+++ b/nsg.tf
@@ -78,6 +78,7 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix        = "*"
     destination_address_prefixes = azurerm_virtual_network.prod_private.address_space
   }
+  #tfsec:ignore:azure-network-no-public-egress
   security_rule {
     name                       = "allow-https-outbound"
     priority                   = 2101

--- a/nsg.tf
+++ b/nsg.tf
@@ -6,6 +6,8 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
   resource_group_name = azurerm_resource_group.prod_public.name
 
   ## Inbound rules
+
+  #tfsec:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-http-inbound"
     priority                   = 100
@@ -17,6 +19,7 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+  #tfsec:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-https-inbound"
     priority                   = 101
@@ -28,6 +31,7 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+  #tfsec:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-ldap-inbound"
     priority                   = 102

--- a/nsg.tf
+++ b/nsg.tf
@@ -40,7 +40,9 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "873"
-    source_address_prefixes    = var.whitelist_ips
+    # 52.202.51.185: pkg.origin.jenkins.io
+    # TODO: replace by the object reference data when all DNS entries will be imported
+    source_address_prefixes = ["52.202.51.185/32"]
     destination_address_prefix = "*"
   }
   security_rule {

--- a/nsg.tf
+++ b/nsg.tf
@@ -4,7 +4,9 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
   location            = var.location
   resource_group_name = azurerm_resource_group.prod_public.name
 
-  # Inbound rules
+  ## Inbound rules
+  #tfsec:ignore:azure-network-no-public-ingress
+
   security_rule {
     name                       = "allow-http-inbound"
     priority                   = 100
@@ -16,6 +18,8 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+  #tfsec:ignore:azure-network-no-public-ingress
+
   security_rule {
     name                       = "allow-https-inbound"
     priority                   = 101
@@ -63,7 +67,7 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     destination_address_prefix = "*"
   }
 
-  # Outbound rules
+  ## Outbound rules
   security_rule {
     name                         = "allow-puppet-outbound"
     priority                     = 2100

--- a/nsg.tf
+++ b/nsg.tf
@@ -6,43 +6,49 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
 
   # Inbound rules
   security_rule {
-    name                   = "allow-http-inbound"
-    priority               = 100
-    direction              = "Inbound"
-    access                 = "Allow"
-    protocol               = "Tcp"
-    source_port_range      = "*"
-    destination_port_range = "80"
-  }
-  security_rule {
-    name                   = "allow-https-inbound"
-    priority               = 101
-    direction              = "Inbound"
-    access                 = "Allow"
-    protocol               = "Tcp"
-    source_port_range      = "*"
-    destination_port_range = "443"
-  }
-  security_rule {
-    name                   = "allow-ldap-inbound"
-    priority               = 102
-    direction              = "Inbound"
-    access                 = "Allow"
-    protocol               = "Tcp"
-    source_port_range      = "*"
-    destination_port_range = "636"
-  }
-  security_rule {
-    name                       = "allow-rsyncd-inbound"
-    priority                   = 103
+    name                       = "allow-http-inbound"
+    priority                   = 100
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "873"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "allow-https-inbound"
+    priority                   = 101
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "allow-ldap-inbound"
+    priority                   = 102
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "636"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                   = "allow-rsyncd-inbound"
+    priority               = 103
+    direction              = "Inbound"
+    access                 = "Allow"
+    protocol               = "Tcp"
+    source_port_range      = "*"
+    destination_port_range = "873"
     # 52.202.51.185: pkg.origin.jenkins.io
     # TODO: replace by the object reference data when all DNS entries will be imported
-    source_address_prefixes = ["52.202.51.185/32"]
+    source_address_prefixes    = ["52.202.51.185/32"]
     destination_address_prefix = "*"
   }
   security_rule {
@@ -64,8 +70,8 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     direction                    = "Outbound"
     access                       = "Allow"
     protocol                     = "Tcp"
-    source_port_range            = "8140"
-    destination_port_range       = "*"
+    source_port_range            = "*"
+    destination_port_range       = "8140"
     source_address_prefix        = "*"
     destination_address_prefixes = azurerm_virtual_network.prod_private.address_space
   }
@@ -76,8 +82,8 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     direction                  = "Outbound"
     access                     = "Allow"
     protocol                   = "Tcp"
-    source_port_range          = "443"
-    destination_port_range     = "*"
+    source_port_range          = "*"
+    destination_port_range     = "443"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/nsg.tf
+++ b/nsg.tf
@@ -1,12 +1,11 @@
 ## Network Security Groups
+#tfsec:ignore:azure-network-no-public-ingress #tfsec:ignore:azure-network-no-public-egress
 resource "azurerm_network_security_group" "prod_public_apptier" {
   name                = "prod-jenkins-public-vnet-apptier"
   location            = var.location
   resource_group_name = azurerm_resource_group.prod_public.name
 
   ## Inbound rules
-  #tfsec:ignore:azure-network-no-public-ingress
-
   security_rule {
     name                       = "allow-http-inbound"
     priority                   = 100
@@ -18,8 +17,6 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-  #tfsec:ignore:azure-network-no-public-ingress
-
   security_rule {
     name                       = "allow-https-inbound"
     priority                   = 101
@@ -79,7 +76,6 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix        = "*"
     destination_address_prefixes = azurerm_virtual_network.prod_private.address_space
   }
-  #tfsec:ignore:azure-network-no-public-egress
   security_rule {
     name                       = "allow-https-outbound"
     priority                   = 2101

--- a/nsg.tf
+++ b/nsg.tf
@@ -1,5 +1,4 @@
 ## Network Security Groups
-#tfsec:ignore:azure-network-no-public-ingress #tfsec:ignore:azure-network-no-public-egress
 resource "azurerm_network_security_group" "prod_public_apptier" {
   name                = "prod-jenkins-public-vnet-apptier"
   location            = var.location
@@ -80,6 +79,7 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     source_address_prefix        = "*"
     destination_address_prefixes = azurerm_virtual_network.prod_private.address_space
   }
+  #tfsec:ignore:azure-network-no-public-egress
   security_rule {
     name                       = "allow-https-outbound"
     priority                   = 2101

--- a/nsg.tf
+++ b/nsg.tf
@@ -46,17 +46,6 @@ resource "azurerm_network_security_group" "prod_public_apptier" {
     destination_address_prefix = "*"
   }
   security_rule {
-    name                       = "allow-public-ssh-inbound"
-    priority                   = 4000
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "22"
-    source_address_prefixes    = azurerm_virtual_network.prod_public.address_space
-    destination_address_prefix = "*"
-  }
-  security_rule {
     name                       = "allow-private-ssh-inbound"
     priority                   = 4001
     direction                  = "Inbound"

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,12 @@ variable "location" {
   type    = string
   default = "East US 2"
 }
+
+variable "whitelist_ips" {
+  description = "A list of IP CIDR ranges to allow as clients. Do not use Azure tags like `Internet`."
+  # 52.167.253.43: prodgw-publick8s
+  # 52.202.51.185: ?
+  # 52.177.88.13: prodpublick8s aks-slb-managed-outbound-ip
+  default = ["52.167.253.43/32", "52.202.51.185/32", "52.177.88.13/32"]
+  type    = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,12 +2,3 @@ variable "location" {
   type    = string
   default = "East US 2"
 }
-
-variable "whitelist_ips" {
-  description = "A list of IP CIDR ranges to allow as clients. Do not use Azure tags like `Internet`."
-  # 52.167.253.43: prodgw-publick8s
-  # 52.202.51.185: ?
-  # 52.177.88.13: prodpublick8s aks-slb-managed-outbound-ip
-  default = ["52.167.253.43/32", "52.202.51.185/32", "52.177.88.13/32"]
-  type    = list(string)
-}


### PR DESCRIPTION
Current `public-network-apptier` network security group:

![image](https://user-images.githubusercontent.com/91831478/203804443-73d920e1-e506-4d96-a130-4ee77832d694.png)

Changes from this list:
- no idea what's the `52.177.106.146` IP correspond to, not found in Azure public IPS, nor in `az vm list-ip-addresses | grep 52.177.106.146` and nor in any @jenkins-infra repositories: rule set aside from this PR
- no idea for `52.202.51.185` too, kept as one of the whitelisted rsyncd inbound IPs

Ref: https://github.com/jenkins-infra/helpdesk/issues/3257
