### PR TITLE
feat: migrate definition of the subnet privatek8s-tier in the private vnet from jenkins-infra/azure

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -54,6 +54,7 @@ resource "azurerm_virtual_network" "private" {
   address_space       = ["10.248.0.0/14"]
   tags                = local.default_tags
 }
+
 # Dedicated subnet for external access (such as VPN external NIC)
 resource "azurerm_subnet" "dmz" {
   name                 = "${azurerm_virtual_network.private.name}-dmz"
@@ -61,6 +62,7 @@ resource "azurerm_subnet" "dmz" {
   virtual_network_name = azurerm_virtual_network.private.name
   address_prefixes     = ["10.248.0.0/28"]
 }
+
 # Dedicated subnet for machine to machine private communications
 resource "azurerm_subnet" "data_tier" {
   name                 = "${azurerm_virtual_network.private.name}-data-tier"
@@ -68,8 +70,9 @@ resource "azurerm_subnet" "data_tier" {
   virtual_network_name = azurerm_virtual_network.private.name
   address_prefixes     = ["10.248.1.0/24"]
 }
-# Dedicated subnet for the AKS cluster 'privatek8s' resources
-## Important: the Enterprise Application "terraform-production" used by this repo pipeline needs to be able to manage this subnet
+
+# Dedicated subnet for the  "privatek8s" AKS cluster resources
+## Important: the "terraform-production" Enterprise Application used by this repo pipeline needs to be able to manage this subnet.
 ## See the corresponding role assignment for this cluster added here (private repo):
 ## https://github.com/jenkins-infra/terraform-states/blob/1f44cdb8c6837021b1007fef383207703b0f4d76/azure/main.tf#L49
 resource "azurerm_subnet" "privatek8s_tier" {

--- a/vnets.tf
+++ b/vnets.tf
@@ -46,10 +46,7 @@ resource "azurerm_virtual_network" "public" {
   tags                = local.default_tags
 }
 
-### Private VNet Address Plan:
-# - azure-net:vnets.tf/dmz = 10.248.0.0/28 (from 10.248.0.1 to 10.248.0.14), for external access (such as VPN external NIC)
-# - azure-net:vpn.tf/data-tier = 10.248.1.0/24 (from 10.248.0.65 to 10.248.1.254), for vpn VM internal NIC
-# - azure:privatek8s.tf/privatek8s-tier = 10.249.0.0/16 (from 10.249.0.1 to 10.249.255.254), for the AKS cluster 
+### Private VNet
 resource "azurerm_virtual_network" "private" {
   name                = "${azurerm_resource_group.private.name}-vnet"
   location            = azurerm_resource_group.private.location
@@ -57,13 +54,29 @@ resource "azurerm_virtual_network" "private" {
   address_space       = ["10.248.0.0/14"]
   tags                = local.default_tags
 }
-
-# Dedicated subnet for external access
+# Dedicated subnet for external access (such as VPN external NIC)
 resource "azurerm_subnet" "dmz" {
   name                 = "${azurerm_virtual_network.private.name}-dmz"
   resource_group_name  = azurerm_resource_group.private.name
   virtual_network_name = azurerm_virtual_network.private.name
   address_prefixes     = ["10.248.0.0/28"]
+}
+# Dedicated subnet for machine to machine private communications
+resource "azurerm_subnet" "data_tier" {
+  name                 = "${azurerm_virtual_network.private.name}-data-tier"
+  resource_group_name  = azurerm_resource_group.private.name
+  virtual_network_name = azurerm_virtual_network.private.name
+  address_prefixes     = ["10.248.1.0/24"]
+}
+# Dedicated subnet for the AKS cluster 'privatek8s' resources
+## Important: the Enterprise Application "terraform-production" used by this repo pipeline needs to be able to manage this subnet
+## See the corresponding role assignment for this cluster added here (private repo):
+## https://github.com/jenkins-infra/terraform-states/blob/1f44cdb8c6837021b1007fef383207703b0f4d76/azure/main.tf#L49
+resource "azurerm_subnet" "privatek8s_tier" {
+  name                 = "privatek8s-tier"
+  resource_group_name  = azurerm_resource_group.private.name
+  virtual_network_name = azurerm_virtual_network.private.name
+  address_prefixes     = ["10.249.0.0/16"]
 }
 
 ## Peering

--- a/vnets.tf
+++ b/vnets.tf
@@ -73,7 +73,7 @@ resource "azurerm_subnet" "data_tier" {
 
 # Dedicated subnet for the  "privatek8s" AKS cluster resources
 ## Important: the "terraform-production" Enterprise Application used by this repo pipeline needs to be able to manage this subnet.
-## See the corresponding role assignment for this cluster added here (private repo):
+## See the corresponding role assignment for this cluster added in the (private) terraform-state repo:
 ## https://github.com/jenkins-infra/terraform-states/blob/1f44cdb8c6837021b1007fef383207703b0f4d76/azure/main.tf#L49
 resource "azurerm_subnet" "privatek8s_tier" {
   name                 = "privatek8s-tier"

--- a/vnets.tf
+++ b/vnets.tf
@@ -64,7 +64,7 @@ resource "azurerm_subnet" "dmz" {
 }
 
 # Dedicated subnet for machine to machine private communications
-resource "azurerm_subnet" "data_tier" {
+resource "azurerm_subnet" "private_vnet_data_tier" {
   name                 = "${azurerm_virtual_network.private.name}-data-tier"
   resource_group_name  = azurerm_resource_group.private.name
   virtual_network_name = azurerm_virtual_network.private.name

--- a/vpn.tf
+++ b/vpn.tf
@@ -44,7 +44,7 @@ resource "azurerm_network_interface" "internal" {
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.data_tier.id
+    subnet_id                     = azurerm_subnet.private_vnet_data_tier.id
     private_ip_address_allocation = "Dynamic"
   }
 

--- a/vpn.tf
+++ b/vpn.tf
@@ -4,14 +4,6 @@ resource "azurerm_resource_group" "vpn" {
   tags     = local.default_tags
 }
 
-# Dedicated subnet in the private vnet
-resource "azurerm_subnet" "data_tier" {
-  name                 = "${azurerm_virtual_network.private.name}-data-tier"
-  resource_group_name  = azurerm_resource_group.private.name
-  virtual_network_name = azurerm_virtual_network.private.name
-  address_prefixes     = ["10.248.1.0/24"]
-}
-
 resource "azurerm_public_ip" "public" {
   name                = "${azurerm_resource_group.vpn.name}-public-ip"
   resource_group_name = azurerm_resource_group.vpn.name


### PR DESCRIPTION
This PR should not change anything: the `privatek8s-tier` subnet was imported in the azure-net's state with the command 

```shell
terraform import 'azurerm_subnet.privatek8s_tier' '/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/private/providers/Microsoft.Network/virtualNetworks/private-vnet/subnets/privatek8s-tier'
```

(edit) internal renaming of the subnet data-tier. Used the command

```
terraform state mv 'azurerm_subnet.data_tier' 'azurerm_subnet.private_vnet_data_tier'
```

to avoid destroy/create.