### PR TITLE
feat(dns) add letsencrypt DNS support for trusted.ci.jenkins.io 

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -34,7 +34,12 @@ resource "azuread_application" "letsencrypt_dns_challenges" {
   for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
 
   display_name = replace(each.key, ".", "_")
+  owners       = [data.azuread_client_config.current.object_id]
   tags         = [for key, value in local.default_tags : "${key}:${value}"]
+
+  web {
+    homepage_url = "https://github.com/jenkins-infra/azure-net"
+  }
 }
 
 resource "azuread_service_principal" "child_zone_service_principals" {

--- a/dns.tf
+++ b/dns.tf
@@ -7,3 +7,53 @@ data "azurerm_resource_group" "proddns_jenkinsio" {
 data "azurerm_dns_zone" "jenkinsio" {
   name = "jenkins.io"
 }
+
+resource "azurerm_dns_zone" "child_zones" {
+  for_each = local.lets_encrypt_dns_challenged_domains
+
+  name = each.key
+  # Use the same resource group for all DNS zones
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+
+  tags = local.default_tags
+}
+
+# create DNS record of type NS for child-zone in the parent zone (to allow propagation of DNS records)
+resource "azurerm_dns_ns_record" "child_zone_ns_records" {
+  for_each = local.lets_encrypt_dns_challenged_domains
+
+  name                = trimsuffix(each.key, ".jenkins.io") # only the flat name not the fqdn
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+
+  records = azurerm_dns_zone.child_zones[each.key].name_servers
+}
+
+resource "azuread_application" "letsencrypt_dns_challenges" {
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+
+  display_name = replace(each.key, ".", "_")
+  tags         = [for key, value in local.default_tags : "${key}:${value}"]
+}
+
+resource "azuread_service_principal" "child_zone_service_principals" {
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+
+  application_id = azuread_application.letsencrypt_dns_challenges[each.key].application_id
+}
+
+resource "azuread_service_principal_password" "child_zone_service_principal_passwords" {
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+
+  display_name         = "Service Principal secret for ${each.key} Let's Encrypt DNS-01 challenges"
+  service_principal_id = azuread_service_principal.child_zone_service_principals[each.key].object_id
+}
+
+resource "azurerm_role_assignment" "child_zone_service_principal_assignements" {
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+
+  scope                = azurerm_dns_zone.child_zones[each.key].id
+  role_definition_name = "DNS Zone Contributor" # Predefined standard role in Azure
+  principal_id         = azuread_service_principal.child_zone_service_principals[each.key].id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -18,4 +18,10 @@ locals {
       puppet_jenkins_io = "140.211.9.94"
     }
   }
+
+  lets_encrypt_dns_challenged_domains = {
+    "trusted.ci.jenkins.io" = "service_principal"
+    ## TODO: add support for workload identities:
+    # "cert.ci.jenkins.io" = "managed_identity"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,2 @@
+# This data source allows referencing the identity used by Terraform to connect to the Azure API
+data "azuread_client_config" "current" {}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3091, this PR adds a DNS zone and associated Azure Service Principal and permissions to allow requesting Let's Encrypt certificates with DNS challenge from the (private) AWS VM hosting trusted.ci.jenkins.io.