### PR TITLE
Revert "hotfix(dns) use existing Azure AD application for Let's Encrypt instead of managing it(s)"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,2 @@
+# This data source allows referencing the identity used by Terraform to connect to the Azure API
+data "azuread_client_config" "current" {}


### PR DESCRIPTION
This reverts commit 77267a9de6afb28ea54085db1823ed1e6d6a0aba.

Now that the terraform's Service Principal [are granted the "Application Developer" role](https://github.com/jenkins-infra/terraform-states/commit/a671b2063bfbe41055dbee5fffb69430ed4d9827) (ref. https://github.com/jenkins-infra/azure-net/pull/30#discussion_r1070178697), the creation of new Azure AD application should work.

https://github.com/jenkins-infra/terraform-states/commit/a671b2063bfbe41055dbee5fffb69430ed4d9827