### PR TITLE
feat(privatek8s): enable KeyVault service endpoint

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -80,6 +80,8 @@ resource "azurerm_subnet" "privatek8s_tier" {
   resource_group_name  = azurerm_resource_group.private.name
   virtual_network_name = azurerm_virtual_network.private.name
   address_prefixes     = ["10.249.0.0/16"]
+  # Enable KeyVault service endpoint so the cluster can access secrets to update other clusters
+  service_endpoints = ["Microsoft.KeyVault"]
 }
 
 ## Peering


### PR DESCRIPTION
Enabling this endpoint so the privatek8s subnet can be added to the prodjenkinsinfra keys vault allowed networks, in order for infra.ci.jenkins.io to access secrets to control and admin other clusters.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844