### PR TITLE
feat: add `repo.azure` CNAME record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -63,3 +63,12 @@ resource "azurerm_role_assignment" "child_zone_service_principal_assignements" {
   role_definition_name = "DNS Zone Contributor" # Predefined standard role in Azure
   principal_id         = azuread_service_principal.child_zone_service_principals[each.key].id
 }
+
+# CNAME record for artifact-caching-proxy on Azure
+resource "azurerm_dns_cname_record" "target" {
+  name                = "repo.azure"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  record              = "public.publick8s.jenkins.io"
+}


### PR DESCRIPTION
As noted in [the terraform provider doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record), CNAME record resource can target either a record or an existing resource.

I chose to target the record `public.publick8s.jenkins.io` as we can't specify multiple resources as target, and as there are two corresponding resources: [an A record and an AAAA record](https://github.com/jenkins-infra/azure/blob/30e3c37e967ae31ca125769a9ee39fe81e99f131/publick8s.tf#L119-L135).

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351 & https://github.com/jenkins-infra/helpdesk/issues/2752