### PR TITLE
fix(dns/letsencrypt) backport azure_ad_application corrections from jenkins-infra/azure + fix naming for passwords

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,9 @@ terraform {
     azurerm = {
       source = "hashicorp/azurerm"
     }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
     local = {
       source = "hashicorp/local"
     }


### PR DESCRIPTION
This PR is a fix around the Lets Encrypt Azure AD resources:

- It backports the practises from jenkins-infra/azure:
  - Define an owner for bot hte Azure AD and the Azure SP from data source 
  - Ensure that app_role_assignment_required is explictly set
  - Add an explicit end date to the Azure AD application password
- It alsos fixes the following:
  - Since the Azure AD password will be regenerated (by adding the endate), then let's fix its name
  - Add a missing explicit provider azuread (to avoid weird terraform provider behavior)