### PR TITLE
feat(dns/letsencrypt) add AD app, SP and DNS resources for `cert.ci.jenkins.io`

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -128,6 +128,7 @@ resource "azurerm_dns_cname_record" "release-ci-jenkins-io" {
 
 # A record for cert.ci.jenkins.io, accessible only via the private VPN
 # TODO: migrate this record to https://github.com/jenkins-infra/azure/blob/3aae66f0443c766301ae81f4d2aac5cec6032935/cert.ci.jenkins.io.tf#L14
+# once the associated resource will be imported and managed in jenkins-infra/azure (Public IP, VM, etc.)
 resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
   name                = "@"
   zone_name           = azurerm_dns_zone.child_zones["cert.ci.jenkins.io"].name

--- a/dns.tf
+++ b/dns.tf
@@ -34,7 +34,7 @@ resource "azurerm_dns_ns_record" "child_zone_ns_records" {
 }
 
 resource "azuread_application" "letsencrypt_dns_challenges" {
-  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value != "" }
 
   display_name = "letsencrypt-${each.key}"
   owners       = [data.azuread_service_principal.terraform-azure-net-production.id]
@@ -55,7 +55,7 @@ resource "azuread_application" "letsencrypt_dns_challenges" {
 }
 
 resource "azuread_service_principal" "child_zone_service_principals" {
-  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value != "" }
 
   app_role_assignment_required = false
   owners                       = [data.azuread_service_principal.terraform-azure-net-production.id]
@@ -64,15 +64,15 @@ resource "azuread_service_principal" "child_zone_service_principals" {
 }
 
 resource "azuread_application_password" "child_zone_app_passwords" {
-  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value != "" }
 
   display_name          = "${each.key}-tf-managed"
   application_object_id = azuread_application.letsencrypt_dns_challenges[each.key].id
-  end_date              = "2024-04-03T20:00:00Z"
+  end_date              = each.value
 }
 
 resource "azurerm_role_assignment" "child_zone_service_principal_assignements" {
-  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value == "service_principal" }
+  for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value != "" }
 
   scope                = azurerm_dns_zone.child_zones[each.key].id
   role_definition_name = "DNS Zone Contributor" # Predefined standard role in Azure
@@ -122,6 +122,18 @@ resource "azurerm_dns_cname_record" "release-ci-jenkins-io" {
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 300
   record              = "private.privatek8s.jenkins.io"
+
+  tags = local.default_tags
+}
+
+# A record for cert.ci.jenkins.io, accessible only via the private VPN
+# TODO: migrate this record to https://github.com/jenkins-infra/azure/blob/3aae66f0443c766301ae81f4d2aac5cec6032935/cert.ci.jenkins.io.tf#L14
+resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
+  name                = "@"
+  zone_name           = azurerm_dns_zone.child_zones["cert.ci.jenkins.io"].name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  records             = ["10.0.2.252"]
 
   tags = local.default_tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -32,8 +32,9 @@ locals {
   }
 
   lets_encrypt_dns_challenged_domains = {
-    "trusted.ci.jenkins.io" = "service_principal"
-    ## TODO: add support for workload identities:
-    # "cert.ci.jenkins.io" = "managed_identity"
+    "trusted.ci.jenkins.io" = "2024-04-03T20:00:00Z"
+    "cert.ci.jenkins.io"    = "2024-04-03T21:00:00Z"
+    # TODO: add support for workload identities by providing an empty expiration date
+    # "cert.ci.jenkins.io" = ""
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -35,6 +35,6 @@ locals {
     "trusted.ci.jenkins.io" = "2024-04-03T20:00:00Z"
     "cert.ci.jenkins.io"    = "2024-04-03T21:00:00Z"
     # TODO: add support for workload identities by providing an empty expiration date
-    # "cert.ci.jenkins.io" = ""
+    # "<something>.jenkins.io" = ""
   }
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3337, follows-up #48

This PR adds the required Azure resources to allow cert.ci.jenkins.io certificate generation with Letsencrypt and Azure DNS.

- A new DNS zone cert.ci.jenkins.io, child of jenkins.io is added (same method as for trusted.ci)
  - Please note that an apex record is required for `cert.ci.jenkins.io`. For now the IP is defined "raw". The record should be defined in https://github.com/jenkins-infra/azure/blob/main/cert.ci.jenkins.io.tf
- The same set of Azure AD, Service principal, AD password and permissions to the new child zone only
- Please note that `locals.tf` has been changed to hold the expiration date:
  - Each SP password will have its own expiration date
  - An empty expiration date means: "use a managed identity" instead of a "AD/SP password"