### PR TITLE
chore(jenkins.io): import `javadoc` and `wiki` CNAME records

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -69,22 +69,40 @@ resource "azurerm_dns_cname_record" "target_private_privatek8s" {
 }
 
 # CNAME records targeting the public-nginx on prodpublick8s cluster
-# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
-resource "azurerm_dns_cname_record" "javadoc" {
-  name                = "javadoc"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  record              = "public.aks.jenkins.io"
-}
+# # TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+# resource "azurerm_dns_cname_record" "javadoc" {
+#   name                = "javadoc"
+#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
+#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+#   ttl                 = 60
+#   record              = "public.aks.jenkins.io"
+# }
 
-# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
-resource "azurerm_dns_cname_record" "wiki" {
-  name                = "wiki"
+# # TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+# resource "azurerm_dns_cname_record" "wiki" {
+#   name                = "wiki"
+#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
+#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+#   ttl                 = 60
+#   record              = "public.aks.jenkins.io"
+# }
+
+resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
+  # Map of records and corresponding purposes
+  for_each = {
+    "javadoc" = "Jenkins Javadoc"
+    "wiki"    = "Static Wiki Confluence export"
+  }
+
+  name                = each.key
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
   record              = "public.aks.jenkins.io"
+
+  tags = merge(local.default_tags, {
+    purpose = each.value
+  })
 }
 
 ### TXT records

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -69,24 +69,7 @@ resource "azurerm_dns_cname_record" "target_private_privatek8s" {
 }
 
 # CNAME records targeting the public-nginx on prodpublick8s cluster
-# # TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
-# resource "azurerm_dns_cname_record" "javadoc" {
-#   name                = "javadoc"
-#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
-#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-#   ttl                 = 60
-#   record              = "public.aks.jenkins.io"
-# }
-
-# # TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
-# resource "azurerm_dns_cname_record" "wiki" {
-#   name                = "wiki"
-#   zone_name           = data.azurerm_dns_zone.jenkinsio.name
-#   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-#   ttl                 = 60
-#   record              = "public.aks.jenkins.io"
-# }
-
+# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
 resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
   # Map of records and corresponding purposes
   for_each = {

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -68,6 +68,25 @@ resource "azurerm_dns_cname_record" "target_private_privatek8s" {
   })
 }
 
+# CNAME records targeting the public-nginx on prodpublick8s cluster
+# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+resource "azurerm_dns_cname_record" "javadoc" {
+  name                = "javadoc"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  record              = "public.aks.jenkins.io"
+}
+
+# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+resource "azurerm_dns_cname_record" "wiki" {
+  name                = "wiki"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  record              = "public.aks.jenkins.io"
+}
+
 ### TXT records
 # TXT record to verify jenkinsci-transfer GitHub org (https://github.com/jenkins-infra/helpdesk/issues/3448)
 resource "azurerm_dns_txt_record" "jenkinsci-transfer-github-verification" {


### PR DESCRIPTION
This PR imports existing CNAME records from the jenkins.io DNS zone.

I've manually lowered their TTL in order to prepare their target switch from prodpublick8s public-nginx address to publick8s public-nginx address.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351
