### PR TITLE
chore(jenkinsistheway.io): import resource group & DNS zone to create a CNAME record instead of a A record

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -77,6 +77,26 @@ resource "azurerm_dns_cname_record" "target_private_privatek8s" {
   })
 }
 
+# CNAME records targeting the public-nginx on prodpublick8s cluster
+# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
+  # Map of records and corresponding purposes
+  for_each = {
+    "javadoc" = "Jenkins Javadoc"
+    "wiki"    = "Static Wiki Confluence export"
+  }
+
+  name                = each.key
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+  record              = "public.aks.jenkins.io"
+
+  tags = merge(local.default_tags, {
+    purpose = each.value
+  })
+}
+
 ### TXT records
 # TXT record to verify jenkinsci-transfer GitHub org (https://github.com/jenkins-infra/helpdesk/issues/3448)
 resource "azurerm_dns_txt_record" "jenkinsci-transfer-github-verification" {

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -12,15 +12,6 @@ resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
   tags = local.default_tags
 }
 
-# TODO: to be replaced by a CNAME targeting public-nginx on publick8s after https://github.com/jenkins-infra/helpdesk/issues/3351
-resource "azurerm_dns_a_record" "jenkinsistheway_io" {
-  name                = "@"
-  zone_name           = data.azurerm_dns_zone.jenkinsistheway_io.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
-  ttl                 = 60
-  records             = ["52.167.253.43"] # aliased as 'prodgw-publick8s' in Azure Portal
-}
-
 ### CNAME records
 # CNAME records targeting the public-nginx on publick8s cluster
 resource "azurerm_dns_cname_record" "target_public_publick8s" {
@@ -95,6 +86,15 @@ resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
   tags = merge(local.default_tags, {
     purpose = each.value
   })
+}
+
+# TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
+resource "azurerm_dns_cname_record" "jenkinsistheway_io" {
+  name                = "@"
+  zone_name           = data.azurerm_dns_zone.jenkinsistheway_io.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
+  ttl                 = 60
+  records             = "public.aks.jenkins.io"
 }
 
 ### TXT records

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -12,6 +12,15 @@ resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
   tags = local.default_tags
 }
 
+# TODO: to be replaced by a CNAME targeting public-nginx on publick8s after https://github.com/jenkins-infra/helpdesk/issues/3351
+resource "azurerm_dns_a_record" "jenkinsistheway_io" {
+  name                = "@"
+  zone_name           = data.azurerm_dns_zone.jenkinsistheway_io.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
+  ttl                 = 60
+  records             = ["52.167.253.43"] # aliased as 'prodgw-publick8s' in Azure Portal
+}
+
 ### CNAME records
 # CNAME records targeting the public-nginx on publick8s cluster
 resource "azurerm_dns_cname_record" "target_public_publick8s" {

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -91,10 +91,10 @@ resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
 # TODO: to be removed after https://github.com/jenkins-infra/helpdesk/issues/3351
 resource "azurerm_dns_cname_record" "jenkinsistheway_io" {
   name                = "@"
-  zone_name           = data.azurerm_dns_zone.jenkinsistheway_io.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
+  zone_name           = azurerm_dns_zone.jenkinsistheway_io.name
+  resource_group_name = azurerm_resource_group.proddns_jenkinsisthewayio.name
   ttl                 = 60
-  records             = "public.aks.jenkins.io"
+  record              = "public.aks.jenkins.io"
 }
 
 ### TXT records

--- a/dns.tf
+++ b/dns.tf
@@ -3,10 +3,19 @@ data "azurerm_resource_group" "proddns_jenkinsio" {
   name = "proddns_jenkinsio"
 }
 
+resource "azurerm_resource_group" "proddns_jenkinsisthewayio" {
+  name = "proddns_jenkinsisthewayio"
+}
+
 # TODO: import as resource
 data "azurerm_dns_zone" "jenkinsio" {
   name                = "jenkins.io"
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+}
+
+resource "azurerm_dns_zone" "jenkinsistheway_io" {
+  name                = "jenkinsistheway.io"
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
 }
 
 resource "azurerm_dns_zone" "child_zones" {

--- a/dns.tf
+++ b/dns.tf
@@ -4,7 +4,8 @@ data "azurerm_resource_group" "proddns_jenkinsio" {
 }
 
 resource "azurerm_resource_group" "proddns_jenkinsisthewayio" {
-  name = "proddns_jenkinsisthewayio"
+  name     = "proddns_jenkinsisthewayio"
+  location = "East US 2"
 }
 
 # TODO: import as resource
@@ -15,7 +16,7 @@ data "azurerm_dns_zone" "jenkinsio" {
 
 resource "azurerm_dns_zone" "jenkinsistheway_io" {
   name                = "jenkinsistheway.io"
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsisthewayio.name
+  resource_group_name = azurerm_resource_group.proddns_jenkinsisthewayio.name
 }
 
 resource "azurerm_dns_zone" "child_zones" {


### PR DESCRIPTION
This PR imports resources related to `jenkinsistheway.io` in order to prepare the migration of the corresponding service to publick8s.

The existing A record pointing to `prodgw-publick8s` (public IP: 52.167.253.43) in Azure Portal doesn't respond:
```
$ dig jenkinsistheway.io

; <<>> DiG 9.10.6 <<>> jenkinsistheway.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 26233
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;jenkinsistheway.io.            IN      A

;; AUTHORITY SECTION:
io.                     1800    IN      SOA     a0.nic.io. hostmaster.donuts.email. 1684255726 7200 900 1209600 3600

;; Query time: 798 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Tue May 16 19:01:20 CEST 2023
;; MSG SIZE  rcvd: 113
```
You had to request Azure DNS in order to get a response:
```
$ dig @ns1-03.azure-dns.com jenkinsistheway.io

; <<>> DiG 9.10.6 <<>> @ns1-03.azure-dns.com jenkinsistheway.io
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44585
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;jenkinsistheway.io.            IN      A

;; ANSWER SECTION:
jenkinsistheway.io.     60      IN      A       52.167.253.43

;; Query time: 32 msec
;; SERVER: 13.107.236.3#53(13.107.236.3)
;; WHEN: Tue May 16 19:06:05 CEST 2023
;; MSG SIZE  rcvd: 63
```

In a pairing session with @dduportal we decided to delete this A record and to create a CNAME record in this PR instead.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351