### PR TITLE
feat(jenkins.io): change `javadoc` CNAME target from `prodpublick8s` to `publick8s`

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -17,6 +17,7 @@ resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
 resource "azurerm_dns_cname_record" "target_public_publick8s" {
   # Map of records and corresponding purposes
   for_each = {
+    "javadoc"    = "Jenkins Javadoc"
     "repo.azure" = "artifact-caching-proxy on Azure"
     "weekly.ci"  = "Jenkins Weekly demo controller"
   }
@@ -73,7 +74,6 @@ resource "azurerm_dns_cname_record" "target_private_privatek8s" {
 resource "azurerm_dns_cname_record" "target_public_prodpublick8s" {
   # Map of records and corresponding purposes
   for_each = {
-    "javadoc" = "Jenkins Javadoc"
     "wiki"    = "Static Wiki Confluence export"
   }
 


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/3938 & #69 

This PR switch the `javadoc` CNAME target from `prodpublick8s` to `publick8s`.

Tested locally by adding `20.119.232.75 javadoc.jenkins.io` to my /etc/hosts.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351