### PR TITLE
chore(dns): set a TTL of 60s on the public_publick8s target until the migration from prodpublick8s is complete

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -38,7 +38,7 @@ resource "azurerm_dns_cname_record" "target_public_publick8s" {
   name                = each.key
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 300
+  ttl                 = 60
   record              = "public.publick8s.jenkins.io"
 
   tags = merge(local.default_tags, {


### PR DESCRIPTION
Setting the same TTL as the CNAME records before their migration in order to avoid `ENOTFOUND` DNS error we encountered when migrating the `javadoc` CNAME record. (service responding on both targets/clusters but different TTL)