### PR TITLE
feat: add a dedicated subnet for postgres server

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -185,7 +185,7 @@ resource "azurerm_subnet" "public_vnet_ci_jenkins_io_controller" {
 # This subnet is reserved as "delegated" for the pgsql server on the public network
 # Ref. https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking
 resource "azurerm_subnet" "public_vnet_postgres_tier" {
-  name                 = "${data.azurerm_virtual_network.public.name}-postgres-tier"
+  name                 = "${azurerm_virtual_network.public.name}-postgres-tier"
   resource_group_name  = azurerm_resource_group.public.name
   virtual_network_name = azurerm_virtual_network.public.name
   address_prefixes     = ["10.245.5.0/24"] # 10.245.5.1 - 10.245.5.254


### PR DESCRIPTION
This PR adds a new subnet dedicated to a postgres server, recreated to avoid network overlap issues from the previous "public" postgres server (see https://github.com/jenkins-infra/azure/pull/354#issuecomment-1554549215).

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351