### PR TITLE
feat(jenkins.io): change `uplink` CNAME target from `prodpublick8s` to `publick8s`

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -1,3 +1,8 @@
+moved {
+  from = azurerm_dns_cname_record.target_public_prodpublick8s["uplink"]
+  to   = azurerm_dns_cname_record.target_public_publick8s["uplink"]
+}
+
 ### A records
 # A record for cert.ci.jenkins.io, accessible only via the private VPN
 # TODO: migrate this record to https://github.com/jenkins-infra/azure/blob/3aae66f0443c766301ae81f4d2aac5cec6032935/cert.ci.jenkins.io.tf#L14

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -1,6 +1,6 @@
 moved {
-  from = azurerm_dns_cname_record.target_public_prodpublick8s["uplink"]
-  to   = azurerm_dns_cname_record.target_public_publick8s["uplink"]
+  from = azurerm_dns_cname_record.jenkinsio_target_public_prodpublick8s["uplink"]
+  to   = azurerm_dns_cname_record.jenkinsio_target_public_publick8s["uplink"]
 }
 
 ### A records

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -61,6 +61,7 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_publick8s" {
     "plugin-health" = "Plugin Health Scoring application"
     "rating"        = "Jenkins releases rating service"
     "repo.azure"    = "artifact-caching-proxy on Azure"
+    "uplink"        = "Jenkins telemetry service"
     "weekly.ci"     = "Jenkins Weekly demo controller"
     "wiki"          = "Static Wiki Confluence export"
   }
@@ -160,7 +161,6 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_prodpublick8s" {
     "plugin-site-issues" = "Plugins website API content origin for Fastly CDN"
     "plugins.origin"     = "Plugins website content origin for Fastly CDN"
     "reports"            = "Public reports about Jenkins services and components consumed by RPU, plugins website and others"
-    "uplink"             = "Jenkins telemetry service"
     "www.origin"         = "Jenkins website content origin for Fastly CDN"
   }
 


### PR DESCRIPTION
To be merged after https://github.com/jenkins-infra/kubernetes-management/pull/4025/

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351