### PR TITLE
feat(jenkins.io): change `accounts` CNAME target from `prodpublick8s` to `publick8s`

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -1,6 +1,6 @@
 moved {
-  from = azurerm_dns_cname_record.jenkinsio_target_public_prodpublick8s["reports"]
-  to   = azurerm_dns_cname_record.jenkinsio_target_public_publick8s["reports"]
+  from = azurerm_dns_cname_record.jenkinsio_target_public_prodpublick8s["accounts"]
+  to   = azurerm_dns_cname_record.jenkinsio_target_public_publick8s["accounts"]
 }
 
 ### A records
@@ -61,6 +61,7 @@ resource "azurerm_dns_aaaa_record" "jenkinsistheway_io_ipv6" {
 resource "azurerm_dns_cname_record" "jenkinsio_target_public_publick8s" {
   # Map of records and corresponding purposes
   for_each = {
+    "accounts"      = "accountapp for Jenkins users"
     "incrementals"  = "incrementals publisher to incrementals Maven repository"
     "javadoc"       = "Jenkins Javadoc"
     "plugin-health" = "Plugin Health Scoring application"
@@ -86,8 +87,9 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_publick8s" {
 resource "azurerm_dns_cname_record" "jenkinsciorg_target_public_publick8s" {
   # Map of records and corresponding purposes. Some records only exists in jenkins.io as jenkins-ci.org is only legacy
   for_each = {
-    "javadoc" = "Jenkins Javadoc"
-    "wiki"    = "Static Wiki Confluence export"
+    "accounts" = "accountapp for Jenkins users"
+    "javadoc"  = "Jenkins Javadoc"
+    "wiki"     = "Static Wiki Confluence export"
   }
 
   name                = each.key
@@ -160,7 +162,6 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_private_privatek8s" {
 resource "azurerm_dns_cname_record" "jenkinsio_target_public_prodpublick8s" {
   # Map of records and corresponding purposes
   for_each = {
-    "accounts"           = "accountapp for Jenkins users"
     "fallback.get"       = "Fallback address for mirrorbits" # Note: had a TTL of 10 minutes before, not 1 hour
     "get"                = "Jenkins binary distribution via mirrorbits"
     "mirrors"            = "Jenkins binary distribution via mirrorbits"


### PR DESCRIPTION
To be merged after https://github.com/jenkins-infra/kubernetes-management/pull/4030, can be reviewed already.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351