### PR TITLE
feat(vnet): add Storage service endpoint to `publick8s-tier` subnet 

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -161,6 +161,8 @@ resource "azurerm_subnet" "publick8s_tier" {
     "10.245.0.0/24",           # 10.245.0.1 - 10.245.0.254
     "fd00:db8:deca:deed::/64", # smaller size as we're using kubenet (required by dual-stack AKS cluster), which allocate one IP per node instead of one IP per pod (in case of Azure CNI)
   ]
+  # Enable Storage service endpoint so the cluster can access restricted storage accounts
+  service_endpoints = ["Microsoft.Storage"]
 }
 
 # Dedicated subnet for machine to machine private communications


### PR DESCRIPTION
This PR adds the Storage service endpoint so the cluster can access restricted storage accounts.

Follow-up of https://github.com/jenkins-infra/azure/pull/385#issuecomment-1577251779

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071