### PR TITLE
chore(dns-records): import `mirrors.jenkins-ci.org` CNAME record

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -108,6 +108,7 @@ resource "azurerm_dns_cname_record" "jenkinsciorg_target_public_publick8s" {
   for_each = {
     "accounts" = "accountapp for Jenkins users"
     "javadoc"  = "Jenkins Javadoc"
+    "mirrors"  = "Jenkins binary distribution via mirrorbits"
     "wiki"     = "Static Wiki Confluence export"
   }
 


### PR DESCRIPTION
Follow-up of #86 

With `azure-net` infra.ci.jenkins.io job disabled, ran the following command locally to execute the import:
```console
$ terraform import 'azurerm_dns_cname_record.jenkinsciorg_target_public_publick8s["mirrors"]' /subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/proddns_jenkinsci/providers/Microsoft.Network/dnsZones/jenkins-ci.org/CNAME/mirrors
```

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1586969797