### PR TITLE
feat(DNS) add CNAME record for Fastly ACME validation for jenkins.io apex

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -187,6 +187,25 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_private_privatek8s" {
   })
 }
 
+# Cname records used for Fastly ACME validations
+resource "azurerm_dns_cname_record" "jenkinsio_acme_fastly" {
+  # Map of records and corresponding purposes
+  for_each = {
+    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com"
+  }
+
+  name                = each.key
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 300
+  record              = each.value
+
+  tags = merge(local.default_tags, {
+    purpose = "ACME validation for Fastly (${each.key})"
+  })
+}
+
+
 ### TXT records
 # TXT record to verify jenkinsci-transfer GitHub org (https://github.com/jenkins-infra/helpdesk/issues/3448)
 resource "azurerm_dns_txt_record" "jenkinsci-transfer-github-verification" {

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
     ssh_allowed_inbound_ips = {
       dduportal = {
         ips = [
-          "85.26.116.129/32",    # Home
+          "85.26.116.129/32", # Home
         ],
         priority = 101,
       },


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3635, this PR creates the CNAME record as described by Fastly to renew the jenkins.io apex TLS certificate.