### PR TITLE
feat(DNS) import Fastly's jenkins.io ACME record

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -191,10 +191,11 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_private_privatek8s" {
 resource "azurerm_dns_cname_record" "jenkinsio_acme_fastly" {
   # Map of records and corresponding purposes
   for_each = {
-    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com",
-    "_acme-challenge.pkg" = "f44lzqsppt1dj85jf3.fastly-validations.com",
+    "_acme-challenge"         = "ohh97689e0dknl1rqp.fastly-validations.com",
+    "_acme-challenge.pkg"     = "f44lzqsppt1dj85jf3.fastly-validations.com",
     "_acme-challenge.plugins" = "tr8qxfomlsxfq1grha.fastly-validations.com",
-    "_acme-challenge.www" = "1vt5byhannlhjvm56n.fastly-validations.com",
+    "_acme-challenge.www"     = "1vt5byhannlhjvm56n.fastly-validations.com",
+    "_acme-challenge.stories" = "k31jn864ll8jjqhmik.fastly-validations.com",
   }
 
   name                = each.key

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -191,7 +191,10 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_private_privatek8s" {
 resource "azurerm_dns_cname_record" "jenkinsio_acme_fastly" {
   # Map of records and corresponding purposes
   for_each = {
-    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com"
+    "_acme-challenge" = "ohh97689e0dknl1rqp.fastly-validations.com",
+    "_acme-challenge.pkg" = "f44lzqsppt1dj85jf3.fastly-validations.com",
+    "_acme-challenge.plugins" = "tr8qxfomlsxfq1grha.fastly-validations.com",
+    "_acme-challenge.www" = "1vt5byhannlhjvm56n.fastly-validations.com",
   }
 
   name                = each.key


### PR DESCRIPTION
This PR follows up #114. It imports 3 existing ACME DNS (CNAME) records for Fastly.