### PR TITLE
feat(publick8s) allow inbound rsync from all external sources for new…

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
     ssh_allowed_inbound_ips = {
       dduportal = {
         ips = [
-          "85.27.34.43/32",  # Home
+          "85.27.34.43/32",    # Home
           "86.202.255.126/32", # Cowork
         ],
         priority = 101,

--- a/nsgs.tf
+++ b/nsgs.tf
@@ -97,17 +97,16 @@ resource "azurerm_network_security_group" "public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+  #tfsec:ignore:azure-network-no-public-ingress
   security_rule {
-    name                   = "allow-rsyncd-inbound"
-    priority               = 103
-    direction              = "Inbound"
-    access                 = "Allow"
-    protocol               = "Tcp"
-    source_port_range      = "*"
-    destination_port_range = "873"
-    # 52.202.51.185: pkg.origin.jenkins.io
-    # TODO: replace by the object reference data when all DNS entries will be imported
-    source_address_prefixes    = ["52.202.51.185/32"]
+    name                       = "allow-rsyncd-inbound"
+    priority                   = 103
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "873"
+    source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
   security_rule {


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/2649

This PR updates the existing rsync inbound network security group rule to allow inbound rsync from any external source to allow the new rsync to be reachable from outside (for now).