### PR TITLE
cleanup(dns-records) remove cert.ci.jenkins.io record (managed in jenkins-infra/azure)

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -1,17 +1,5 @@
 ### A and AAAA records
 ## jenkins.io DNS zone records
-# A record for cert.ci.jenkins.io, accessible only via the private VPN
-# TODO: migrate this record to https://github.com/jenkins-infra/azure/blob/3aae66f0443c766301ae81f4d2aac5cec6032935/cert.ci.jenkins.io.tf#L14
-# once the associated resource will be imported and managed in jenkins-infra/azure (Public IP, VM, etc.)
-resource "azurerm_dns_a_record" "cert-ci-jenkins-io" {
-  name                = "@"
-  zone_name           = azurerm_dns_zone.child_zones["cert.ci.jenkins.io"].name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 300
-  records             = ["10.0.2.252"]
-
-  tags = local.default_tags
-}
 
 # Apex ("@") records for the jenkins.io zone
 resource "azurerm_dns_a_record" "jenkins_io" {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3688, this PR removes the managed DNS record from this repository in favor of https://github.com/jenkins-infra/azure/blob/58e52440a4ba252afb140064a0667fafebe6d4fc/cert.ci.jenkins.io.tf#L62-L68 

(otherwise both projects are competing to control this record and its value).