### PR TITLE
fix(DNS) remove fastly-managed acme challenge for jenkins.io

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -217,7 +217,6 @@ resource "azurerm_dns_cname_record" "jenkinsio_acme_fastly" {
     "_acme-challenge.plugins" = "tr8qxfomlsxfq1grha.fastly-validations.com",
     "_acme-challenge.stories" = "k31jn864ll8jjqhmik.fastly-validations.com",
     "_acme-challenge.www"     = "1vt5byhannlhjvm56n.fastly-validations.com",
-    "_acme-challenge"         = "ohh97689e0dknl1rqp.fastly-validations.com",
   }
 
   name                = each.key

--- a/vnets.tf
+++ b/vnets.tf
@@ -216,7 +216,7 @@ resource "azurerm_subnet" "public_db_vnet_mysql_tier" {
   name                 = "${azurerm_virtual_network.public_db.name}-mysql-tier"
   resource_group_name  = azurerm_resource_group.public.name
   virtual_network_name = azurerm_virtual_network.public_db.name
-  address_prefixes     = ["10.253.1.0/24"]     # 10.253.1.1 - 10.253.1.254
+  address_prefixes     = ["10.253.1.0/24"] # 10.253.1.1 - 10.253.1.254
 
   delegation {
     name = "mysql"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3748, this PR removes the `acme` challenge static DNS `TXT` record used to manage TLS certificate for `jenkins.io` by fastly.

Please note the diff should not show anything as the record was removed manually: the PR is only to avoid recreating it later