### PR TITLE
chore: migrate from tfsec to trivy

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version = "2.42.0"
   hashes = [
     "h1:5+ItCYcLIRXgdfBQhmcgYP8/q0WgQh6D9QZssGMcoqo=",
+    "h1:DZ2GTCECB8s/ZY7RAlIhUSH1cGQKUp1YphzJD1ObsIs=",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
     "zh:1ebf629ae485875bb80bf5752122ada01ee602cfb0fa01106621c7e730c10e0a",
     "zh:33ac22d0c308fc3d8cf7fc35f4ee7b616069b6ea2a9f5692b438b8c9013b9664",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version = "3.73.0"
   hashes = [
     "h1:+Z5ZcAQO4e6aWh1N7zX4JqyV/xnDkTRYoCa8pEtNR20=",
+    "h1:5IbjnqJaOdgJp0IX3hFOegOZyxqJ18qUTazt1Dzxq+U=",
     "zh:068dfe743c9486d09eeaf97eb7817870b932ecb8132b92b8e0d96eadcf51b349",
     "zh:2a16b0d50feb80919880d32cc12d636c37918bbc9133d7b3ff0d610bac1bee86",
     "zh:2a77e0deabd3d0f83974125cedca7871add825bf4470688f117a35b6964916cf",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version = "2.4.0"
   hashes = [
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/local" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/nsgs.tf
+++ b/nsgs.tf
@@ -60,8 +60,7 @@ resource "azurerm_network_security_group" "public_apptier" {
   tags = local.default_tags
 
   ## Inbound rules
-
-  #tfsec:ignore:azure-network-no-public-ingress
+  #trivy:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-http-inbound"
     priority                   = 100
@@ -73,7 +72,7 @@ resource "azurerm_network_security_group" "public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-  #tfsec:ignore:azure-network-no-public-ingress
+  #trivy:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-https-inbound"
     priority                   = 101
@@ -85,7 +84,7 @@ resource "azurerm_network_security_group" "public_apptier" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
-  #tfsec:ignore:azure-network-no-public-ingress
+  #trivy:ignore:azure-network-no-public-ingress
   security_rule {
     name                       = "allow-ldap-inbound"
     priority                   = 102
@@ -134,7 +133,7 @@ resource "azurerm_network_security_group" "public_apptier" {
     source_address_prefix        = "*"
     destination_address_prefixes = azurerm_virtual_network.private.address_space
   }
-  #tfsec:ignore:azure-network-no-public-egress
+  #trivy:ignore:azure-network-no-public-egress
   security_rule {
     name                       = "allow-https-outbound"
     priority                   = 2101


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3753

This PR updates tooling to use `trivy` instead of `tfsec`