### PR TITLE
feat(DNS) delegate `do.jenkins.io` to DigitalOcean DNS zone

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -42,6 +42,18 @@ resource "azurerm_dns_ns_record" "cloudflare_jenkins_io" {
   tags = local.default_tags
 }
 
+# NS records pointing to DigitalOcean name servers to delegate do.jenkins.io to them
+resource "azurerm_dns_ns_record" "do_jenkins_io" {
+  name                = "do"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+
+  records = ["ns1.digitalocean.com", "ns2.digitalocean.com", "ns3.digitalocean.com"]
+
+  tags = local.default_tags
+}
+
 resource "azurerm_dns_zone" "child_zones" {
   for_each = local.lets_encrypt_dns_challenged_domains
 


### PR DESCRIPTION
Following the creation of a DNS zone in DigitalOcean in https://github.com/jenkins-infra/digitalocean/pull/161 for the subdomain `do.jenkins.io`, this PR creates the required `NS` records in Azure to delegate DNS resolution for this domain.


(edited) The following DNS records created manually will have to be removed from once the NS records are propagated:

- `repo.do` (already existing in the new zone)
- `_acme-challenge.repo.do` (we use HTTP-01 for now on `doks-public`)