### PR TITLE
chore(updates.jenkins.io): remove `cloudflare.jenkins.io` NS record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -30,18 +30,6 @@ resource "azurerm_dns_zone" "jenkinsistheway_io" {
   resource_group_name = azurerm_resource_group.proddns_jenkinsisthewayio.name
 }
 
-# NS records pointing to CloudFlare name servers to delegate cloudflare.jenkins.io to them
-resource "azurerm_dns_ns_record" "cloudflare_jenkins_io" {
-  name                = "cloudflare"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-
-  records = ["anton.ns.cloudflare.com", "bailey.ns.cloudflare.com"]
-
-  tags = local.default_tags
-}
-
 # NS records pointing to DigitalOcean name servers to delegate do.jenkins.io to them
 resource "azurerm_dns_ns_record" "do_jenkins_io" {
   name                = "do"


### PR DESCRIPTION
This PR removes the NS record corresponding to the initial `cloudflare.jenkins.io`, since deleted.

Follow-up of https://github.com/jenkins-infra/cloudflare/pull/10