### PR TITLE
feat(DNS) import existing CAA records for jenkins.io and jenkins-ci.org

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -49,6 +49,46 @@ resource "azurerm_dns_aaaa_record" "jenkinsciorg" {
   })
 }
 
+# CAA records to restrict Certificate Authorities
+resource "azurerm_dns_caa_record" "jenkins_caa" {
+  for_each = {
+    "${data.azurerm_dns_zone.jenkinsio.name}"    = "${data.azurerm_dns_zone.jenkinsio.resource_group_name}",
+    "${data.azurerm_dns_zone.jenkinsciorg.name}" = "${data.azurerm_dns_zone.jenkinsciorg.resource_group_name}",
+  }
+  name                = "@"
+  zone_name           = each.key
+  resource_group_name = each.value
+  ttl                 = 60
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "godaddy.com"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "amazon.com"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "globalsign.com"
+  }
+
+  tags = merge(local.default_tags, {
+    purpose = "Jenkins user authentication service"
+  })
+}
+
 # A record for ldap.jenkins.io pointing to its own public LB IP from publick8s cluster
 resource "azurerm_dns_a_record" "ldap_jenkins_io" {
   name                = "ldap"


### PR DESCRIPTION
This PR defines the existing `CAA` DNS records for `jenkins.io` and `jenkins-ci.org`.

These records have been imported in the terraform state. Merging this PR will apply the following changes (only add tags to the records):

```
# azurerm_dns_caa_record.jenkins_caa["jenkins-ci.org"] will be updated in-place
  ~ resource "azurerm_dns_caa_record" "jenkins_caa" {
        id                  = "/subscriptions/<redacted>/resourceGroups/proddns_jenkinsci/providers/Microsoft.Network/dnsZones/jenkins-ci.org/CAA/@"
        name                = "@"
      ~ tags                = {
          + "purpose"    = "Jenkins user authentication service"
          + "repository" = "jenkins-infra/azure-net"
          + "scope"      = "terraform-managed"
        }
        # (4 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # azurerm_dns_caa_record.jenkins_caa["jenkins.io"] will be updated in-place
  ~ resource "azurerm_dns_caa_record" "jenkins_caa" {
        id                  = "/subscriptions/<redacted>/resourceGroups/proddns_jenkinsio/providers/Microsoft.Network/dnsZones/jenkins.io/CAA/@"
        name                = "@"
      ~ tags                = {
          + "purpose"    = "Jenkins user authentication service"
          + "repository" = "jenkins-infra/azure-net"
          + "scope"      = "terraform-managed"
        }
        # (4 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```