### PR TITLE
feat(updates.jenkins.io): add CAA record for `westeurope.cloudflare.jenkins.io`

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -121,7 +121,7 @@ resource "azurerm_dns_caa_record" "westeurope_cloudflare_jenkins_io" {
   }
 
   tags = merge(local.default_tags, {
-    purpose = "Jenkins user authentication service"
+    purpose = "CAA record to allow CloudFlare creating an Edge Certificate for westeurope.cloudflare.jenkins.io"
   })
 }
 

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -105,7 +105,7 @@ resource "azurerm_dns_caa_record" "westeurope_cloudflare_jenkins_io" {
   record {
     flags = 0
     tag   = "issue"
-    value = "digicert.com"
+    value = "digicert.com; cansignhttpexchanges=yes"
   }
 
   record {
@@ -117,7 +117,7 @@ resource "azurerm_dns_caa_record" "westeurope_cloudflare_jenkins_io" {
   record {
     flags = 0
     tag   = "issue"
-    value = "pki.goog"
+    value = "pki.goog; cansignhttpexchanges=yes"
   }
 
   tags = merge(local.default_tags, {

--- a/dns-records.tf
+++ b/dns-records.tf
@@ -89,6 +89,42 @@ resource "azurerm_dns_caa_record" "jenkins_caa" {
   })
 }
 
+# CAA records to restrict Certificate Authorities for westeurope.cloudflare.jenkins.io
+resource "azurerm_dns_caa_record" "westeurope_cloudflare_jenkins_io" {
+  name                = "westeurope.cloudflare"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_dns_zone.jenkinsio.resource_group_name
+  ttl                 = 60
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "digicert.com"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "sectigo.com"
+  }
+
+  record {
+    flags = 0
+    tag   = "issue"
+    value = "pki.goog"
+  }
+
+  tags = merge(local.default_tags, {
+    purpose = "Jenkins user authentication service"
+  })
+}
+
 # A record for ldap.jenkins.io pointing to its own public LB IP from publick8s cluster
 resource "azurerm_dns_a_record" "ldap_jenkins_io" {
   name                = "ldap"


### PR DESCRIPTION
This PR adds CAA record for `westeurope.cloudflare` so CloudFlare can (hopefully) generate an Edge Certificate for its `westeurope.cloudflare.jenkins.io` zone (currently stuck in "pending validation")

Corresponding doc: https://developers.cloudflare.com/ssl/edge-certificates/caa-records/#caa-records-added-by-cloudflare

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649