### PR TITLE
chore: use shared admins from shared-tools module

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,27 +7,6 @@ locals {
   vpn = {
     shorthostname = "private.vpn"
     username      = "jenkins-infra-team"
-    ssh_allowed_inbound_ips = {
-      dduportal = {
-        ips = [
-          "109.88.234.158/32",
-          "86.202.255.126/32",
-        ],
-        priority = 101,
-      },
-      lemeurherve = {
-        ips      = ["176.185.227.180/32"],
-        priority = 102,
-      }
-      smerle33 = {
-        ips      = ["82.64.5.129/32"],
-        priority = 103,
-      }
-      mwaite = {
-        ips      = ["162.142.59.220/32"]
-        priority = 104,
-      }
-    }
     puppet_outbound_ips = {
       # dig puppet.jenkins.io
       puppet_jenkins_io = "20.12.27.65"

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,6 @@ data "azuread_service_principal" "terraform-azure-net-production" {
   display_name = "terraform-azure-net-production"
 }
 
-module "jenkins_infra" {
+module "jenkins_infra_shared_data" {
   source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
 }

--- a/main.tf
+++ b/main.tf
@@ -2,3 +2,7 @@
 data "azuread_service_principal" "terraform-azure-net-production" {
   display_name = "terraform-azure-net-production"
 }
+
+module "jenkins_infra" {
+  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
+}

--- a/vpn.tf
+++ b/vpn.tf
@@ -52,10 +52,10 @@ resource "azurerm_network_interface" "internal" {
 }
 
 resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_vpn" {
-  for_each = module.jenkins_infra.admin_public_ips
+  for_each = module.jenkins_infra_shared_data.admin_public_ips
 
   name                        = "allow-ssh-from-${each.key}-to-vpn"
-  priority                    = 101 + (index(keys(module.jenkins_infra.admin_public_ips), each.key))
+  priority                    = 101 + (index(keys(module.jenkins_infra_shared_data.admin_public_ips), each.key))
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"

--- a/vpn.tf
+++ b/vpn.tf
@@ -52,16 +52,16 @@ resource "azurerm_network_interface" "internal" {
 }
 
 resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_vpn" {
-  for_each = local.vpn.ssh_allowed_inbound_ips
+  for_each = module.jenkins_infra.admin_public_ips
 
   name                        = "allow-ssh-from-${each.key}-to-vpn"
-  priority                    = each.value.priority
+  priority                    = 101 + (index(keys(module.jenkins_infra.admin_public_ips), each.key))
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefixes     = each.value.ips
+  source_address_prefixes     = each.value
   destination_address_prefix  = azurerm_network_interface.main.private_ip_address
   resource_group_name         = azurerm_resource_group.private.name
   network_security_group_name = azurerm_network_security_group.private_dmz.name


### PR DESCRIPTION
Twin of of https://github.com/jenkins-infra/digitalocean/pull/165

This PR is a first try at sharing a set common values across our terraform projects.

A new [data-only Terraform module](https://developer.hashicorp.com/terraform/language/modules/develop/composition#data-only-modules) has been added in the jenkins-infra/shared-tools to hold the shared values: https://github.com/jenkins-infra/shared-tools/commit/36589078701232007dbdf8b5034fd93901d072c3.

The following changes are introduced to the vpn VM:

- Use "IP" instead of CIDR mask for firewall rules
- Update current SSH inbound admin IPs to the shared list

💡 Notes:

- This module, for now, only specify a set of outputs providing the shared data to projects. It may provide data sources (Azure DNS zones or network ids?) in the future if need be for instance.
- The choice of mixing IPv6 and IPv4 in the string arrays is because most of the usages requires both. If we need to filter by type, we can use `can(cidrnetmask(...)` and `!can(cidrnetmask(...))` (ref. https://developer.hashicorp.com/terraform/language/functions/cidrnetmask)
- The idea is that, in the near future, each terraform project should be able to update the values of the module when needed (case of public or outbound IPs of our services) or a human (admin IPs).





