### PR TITLE
chore(infra.ci) fix depreciation messages from the `azuread` provider

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -93,15 +93,15 @@ resource "azuread_service_principal" "child_zone_service_principals" {
   app_role_assignment_required = false
   owners                       = [data.azuread_service_principal.terraform-azure-net-production.id]
 
-  application_id = azuread_application.letsencrypt_dns_challenges[each.key].application_id
+  client_id = azuread_application.letsencrypt_dns_challenges[each.key].application_id
 }
 
 resource "azuread_application_password" "child_zone_app_passwords" {
   for_each = { for key, value in local.lets_encrypt_dns_challenged_domains : key => value if value != "" }
 
-  display_name          = "${each.key}-tf-managed"
-  application_object_id = azuread_application.letsencrypt_dns_challenges[each.key].id
-  end_date              = each.value
+  display_name   = "${each.key}-tf-managed"
+  application_id = azuread_application.letsencrypt_dns_challenges[each.key].id
+  end_date       = each.value
 }
 
 resource "azurerm_role_assignment" "child_zone_service_principal_assignements" {

--- a/dns.tf
+++ b/dns.tf
@@ -93,7 +93,7 @@ resource "azuread_service_principal" "child_zone_service_principals" {
   app_role_assignment_required = false
   owners                       = [data.azuread_service_principal.terraform-azure-net-production.id]
 
-  client_id = azuread_application.letsencrypt_dns_challenges[each.key].application_id
+  client_id = azuread_application.letsencrypt_dns_challenges[each.key].client_id
 }
 
 resource "azuread_application_password" "child_zone_app_passwords" {


### PR DESCRIPTION
This warning messages started since https://github.com/hashicorp/terraform-provider-azuread/releases/tag/v2.44.0.

It's mainly a renaming of the attributes which helps to avoid confusion between `id`, `object_id`, `client_id` and `application_id` (not mentioning `application_object_id` 🤣 )