### PR TITLE
cleanup(DNS) remove stats.jenkins-ci.org 

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -199,7 +199,6 @@ resource "azurerm_dns_cname_record" "jenkinsciorg_target_public_publick8s" {
     "accounts" = "accountapp for Jenkins users"
     "javadoc"  = "Jenkins Javadoc"
     "mirrors"  = "Jenkins binary distribution via mirrorbits"
-    "stats"    = "Graphical representations of numbers and information around Jenkins"
     "wiki"     = "Static Wiki Confluence export"
   }
 


### PR DESCRIPTION
as it only responds with HTTP/404 despite pointing to `stats.jenkins.io`.
It's due to how GitHub Pages handles incoming requests: only 1 level of subdomain is allowed.


