### PR TITLE
feat: add the public vnet for the secondary (sponsored) subscription

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,11 @@
-# Configure the Microsoft Azure Provider
+# Configure the Microsoft Azure Providers
 provider "azurerm" {
+  skip_provider_registration = "true"
+  features {}
+}
+provider "azurerm" {
+  alias                      = "jenkins-sponsorship"
+  subscription_id            = "1311c09f-aee0-4d6c-99a4-392c2b543204"
   skip_provider_registration = "true"
   features {}
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1814901484

This PR adds a resource group and a public vnet within the new (sponsored) subscription).

- The new vnet as a `/14 IPv4 only (no IPv6 for now as we don't have the need... yet).