### PR TITLE
feat(gateways) add NAT gateways for sponsorships

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -1,26 +1,6 @@
 ####################################################################################
 ## NAT gateway to allow outbound connection on a centralized and scalable appliance
 ####################################################################################
-moved {
-  from = azurerm_public_ip.cert_ci_jenkins_io_outbound
-  to   = module.cert_ci_jenkins_io_outbound.azurerm_public_ip.outbound
-}
-moved {
-  from = azurerm_nat_gateway.cert_ci_jenkins_io_outbound
-  to   = module.cert_ci_jenkins_io_outbound.azurerm_nat_gateway.outbound
-}
-moved {
-  from = azurerm_nat_gateway_public_ip_association.cert_ci_jenkins_io_outbound
-  to   = module.cert_ci_jenkins_io_outbound.azurerm_nat_gateway_public_ip_association.outbound
-}
-moved {
-  from = azurerm_subnet_nat_gateway_association.cert_ci_jenkins_io_outbound_controller
-  to   = module.cert_ci_jenkins_io_outbound.azurerm_subnet_nat_gateway_association.outbound["cert-ci-jenkins-io-vnet-controller"]
-}
-moved {
-  from = azurerm_subnet_nat_gateway_association.cert_ci_jenkins_io_outbound_ephemeral_agents
-  to   = module.cert_ci_jenkins_io_outbound.azurerm_subnet_nat_gateway_association.outbound["cert-ci-jenkins-io-vnet-ephemeral-agents"]
-}
 module "cert_ci_jenkins_io_outbound" {
   source = "./.shared-tools/terraform/modules/azure-nat-gateway"
 
@@ -32,33 +12,23 @@ module "cert_ci_jenkins_io_outbound" {
     azurerm_subnet.cert_ci_jenkins_io_ephemeral_agents.name,
   ]
 }
+module "cert_ci_jenkins_io_outbound_sponsorship" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  providers = {
+    azurerm = azurerm.jenkins-sponsorship
+  }
+
+  name                = "cert-ci-jenkins-io-outbound-sponsorship"
+  resource_group_name = azurerm_virtual_network.cert_ci_jenkins_io_sponsorship.resource_group_name
+  vnet_name           = azurerm_virtual_network.cert_ci_jenkins_io_sponsorship.name
+  subnet_names = [
+    azurerm_subnet.cert_ci_jenkins_io_sponsorship_ephemeral_agents.name,
+  ]
+}
 ####################################################################################
 ## NAT gateway to allow outbound connection on a centralized and scalable appliance
 ####################################################################################
-moved {
-  from = azurerm_public_ip.trusted_outbound
-  to   = module.trusted_outbound.azurerm_public_ip.outbound
-}
-moved {
-  from = azurerm_nat_gateway.trusted_outbound
-  to   = module.trusted_outbound.azurerm_nat_gateway.outbound
-}
-moved {
-  from = azurerm_nat_gateway_public_ip_association.trusted_outbound
-  to   = module.trusted_outbound.azurerm_nat_gateway_public_ip_association.outbound
-}
-moved {
-  from = azurerm_subnet_nat_gateway_association.trusted_outbound_controller
-  to   = module.trusted_outbound.azurerm_subnet_nat_gateway_association.outbound["trusted-ci-jenkins-io-vnet-controller"]
-}
-moved {
-  from = azurerm_subnet_nat_gateway_association.trusted_outbound_ephemeral_agents
-  to   = module.trusted_outbound.azurerm_subnet_nat_gateway_association.outbound["trusted-ci-jenkins-io-vnet-ephemeral-agents"]
-}
-moved {
-  from = azurerm_subnet_nat_gateway_association.trusted_outbound_permanent_agents
-  to   = module.trusted_outbound.azurerm_subnet_nat_gateway_association.outbound["trusted-ci-jenkins-io-vnet-permanent-agents"]
-}
 module "trusted_outbound" {
   source = "./.shared-tools/terraform/modules/azure-nat-gateway"
 
@@ -69,5 +39,19 @@ module "trusted_outbound" {
     azurerm_subnet.trusted_ci_jenkins_io_controller.name,
     azurerm_subnet.trusted_ci_jenkins_io_permanent_agents.name,
     azurerm_subnet.trusted_ci_jenkins_io_ephemeral_agents.name,
+  ]
+}
+module "trusted_outbound_sponsorship" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  providers = {
+    azurerm = azurerm.jenkins-sponsorship
+  }
+
+  name                = "trusted-outbound-sponsorship"
+  resource_group_name = azurerm_virtual_network.trusted_ci_jenkins_io_sponsorship.resource_group_name
+  vnet_name           = azurerm_virtual_network.trusted_ci_jenkins_io_sponsorship.name
+  subnet_names = [
+    azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.name,
   ]
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1874074475

This PR adds a NAT gateway for both trusted.ci and cert.ci sponsorship networks to ensure the same outbound IP over time (even if it is a second IP)