### PR TITLE
feat(gateways) add NAT gateways for the publick8s and privatek8s clusters

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -84,3 +84,25 @@ module "ci_jenkins_io_outbound_sponsorship" {
     azurerm_subnet.public_jenkins_sponsorship_vnet_ci_jenkins_io_agents.name,
   ]
 }
+
+module "privatek8s_outbound" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  name                = "privatek8s-outbound"
+  resource_group_name = azurerm_virtual_network.private.resource_group_name
+  vnet_name           = azurerm_virtual_network.private.name
+  subnet_names = [
+    azurerm_subnet.privatek8s_tier.name,
+  ]
+}
+
+module "publick8s_outbound" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  name                = "publick8s-outbound"
+  resource_group_name = azurerm_virtual_network.public.resource_group_name
+  vnet_name           = azurerm_virtual_network.public.name
+  subnet_names = [
+    azurerm_subnet.publick8s_tier.name,
+  ]
+}

--- a/gateways.tf
+++ b/gateways.tf
@@ -92,7 +92,8 @@ module "privatek8s_outbound" {
   resource_group_name = azurerm_virtual_network.private.resource_group_name
   vnet_name           = azurerm_virtual_network.private.name
   subnet_names = [
-    azurerm_subnet.privatek8s_tier.name,
+    ## Commented for phase 1 of https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1905856702
+    # azurerm_subnet.privatek8s_tier.name,
   ]
 }
 
@@ -103,6 +104,7 @@ module "publick8s_outbound" {
   resource_group_name = azurerm_virtual_network.public.resource_group_name
   vnet_name           = azurerm_virtual_network.public.name
   subnet_names = [
-    azurerm_subnet.publick8s_tier.name,
+    ## ## Commented for phase 1 of https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1905856702
+    # azurerm_subnet.publick8s_tier.name,
   ]
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3908, this PR adds 2 new NAT gateways, associated with the 2 AKS clusters.

The goal is to have implicit NAT gateway for outbound connection from the AKS cluster subnets which will take precedence over the outbound LB (as changing the cluster to explicit NAT gateway would re-create the cluster which we might not want).

Source: https://www.danielstechblog.io/preventing-snat-port-exhaustion-on-azure-kubernetes-service-with-virtual-network-nat/