### PR TITLE
feat(gateways) add a NAT gateway to privatek8s for outbound requests

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -92,8 +92,7 @@ module "privatek8s_outbound" {
   resource_group_name = azurerm_virtual_network.private.resource_group_name
   vnet_name           = azurerm_virtual_network.private.name
   subnet_names = [
-    ## Commented for phase 1 of https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1905856702
-    # azurerm_subnet.privatek8s_tier.name,
+    azurerm_subnet.privatek8s_tier.name,
   ]
 }
 


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1906084976, this PR associates the `private_outbound` NAT gateway to the `privatek8s` cluster's subnet to use it as the main outbound link.