### PR TITLE
feat(gateways) add all privatek8s operational subnets

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -93,6 +93,8 @@ module "privatek8s_outbound" {
   vnet_name           = azurerm_virtual_network.private.name
   subnet_names = [
     azurerm_subnet.privatek8s_tier.name,
+    azurerm_subnet.privatek8s_release_tier.name,
+    azurerm_subnet.private_vnet_data_tier.name,
   ]
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3908

This PR links all private subnets we added manually during the NAT gateway tests.