### PR TITLE
feat(gateways) use NAT gateway for outbound connections on publick8s

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -105,7 +105,6 @@ module "publick8s_outbound" {
   resource_group_name = azurerm_virtual_network.public.resource_group_name
   vnet_name           = azurerm_virtual_network.public.name
   subnet_names = [
-    ## ## Commented for phase 1 of https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1905856702
-    # azurerm_subnet.publick8s_tier.name,
+    azurerm_subnet.publick8s_tier.name,
   ]
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3908

This is a twin of https://github.com/jenkins-infra/azure-net/pull/199 but for `publick8s`.

Note that the NAT gateway public IP has been added to `publick8s` API allow-list (AKS self-management), along with the `privatek8s` (kubernetes-management + terraform azure)