### PR TITLE
feat(gateways) setup ci.jenkins.io sponsorship controller subnet to use NAT gateway

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -82,6 +82,7 @@ module "ci_jenkins_io_outbound_sponsorship" {
   vnet_name           = azurerm_virtual_network.public_jenkins_sponsorship.name
   subnet_names = [
     azurerm_subnet.public_jenkins_sponsorship_vnet_ci_jenkins_io_agents.name,
+    azurerm_subnet.ci_jenkins_io_controller_sponsorship.name,
   ]
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3913

The goal is to have the new VM for ci.jenkins.io controller (in the sponsorship subscription) to use the NAT gateway for outbound (same as agents, same IP, already allowed in the LDAP for instance)