### PR TITLE
feat(gateways) spread trusted.ci agents outbound trafic to 3 IPs instead of 1

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -52,6 +52,7 @@ module "trusted_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.trusted_ci_jenkins_io_sponsorship_ephemeral_agents.name,
   ]
+  outbound_ip_count = 3
 }
 
 module "ci_jenkins_io_outbound" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,29 @@
+######################################################## Gateways Outbound IPs
+output "cert_ci_outbound_ip_list" {
+  value = module.cert_ci_jenkins_io_outbound.public_ip_list
+}
+output "cert_ci_sponsorship_outbound_ip_list" {
+  value = module.cert_ci_jenkins_io_outbound_sponsorship.public_ip_list
+}
+output "trusted_ci_outbound_ip_list" {
+  value = module.trusted_outbound.public_ip_list
+}
+output "trusted_ci_sponsorship_outbound_ip_list" {
+  value = module.trusted_outbound_sponsorship.public_ip_list
+}
+output "ci_outbound_ip_list" {
+  value = module.ci_jenkins_io_outbound.public_ip_list
+}
+output "ci_sponsorship_outbound_ip_list" {
+  value = module.ci_jenkins_io_outbound_sponsorship.public_ip_list
+}
+output "infra_ci_outbound_ip_list" {
+  value = module.infra_ci_outbound_sponsorship.public_ip_list
+}
+output "publick8s_outbound_ip_list" {
+  value = module.publick8s_outbound.public_ip_list
+}
+output "privatek8s_outbound_ip_list" {
+  value = module.privatek8s_outbound.public_ip_list
+}
+##############################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 ######################################################## Gateways Outbound IPs
-output "cert_ci_outbound_ip_list" {
+output "cert_ci_outbound_ips" {
   value = module.cert_ci_jenkins_io_outbound.public_ip_list
 }
 output "cert_ci_sponsorship_outbound_ip_list" {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4029

This PR requires https://github.com/jenkins-infra/shared-tools/pull/145 to be able to work. It will be kept as a draft until resolved.

It introduces 2 new additional outbound public IPs to the NAT gateway used by the trusted.ci.jenkins.io agents. The goal is to spread the request to the DockerHub across 3 IPs to avoid triggering the anti-abuse.

Docker told us that we usually make peaks of 2200 req / min when releasing a Docker image (inbound agent): that would make them see around 740 req / min instead (see issue for more details)


Note: billing consideration: these additional IPs are billed but in the Azure account where we have sponsor credits. It won't increase the usual Azure account bill (paid by CDF).


----

Once merged, we'll have to retrieve the outbound IPs and update the 2 following locations:

- https://github.com/jenkins-infra/shared-tools/blob/78e8dc498bb63beff855442dcc557eac2b0f7317/terraform/modules/jenkins-infra-shared-data/outputs.tf#L26
- https://github.com/jenkins-infra/terraform-states/blob/a724fa6531ee11ce822319d45bbbefb06dda1c9a/cloudflare/locals.tf#L17