### PR TITLE
fix(gateways) add missing infra.ci agents subnet to use NAT gateway instead SNAT for outbound method

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -92,6 +92,7 @@ module "privatek8s_outbound" {
     azurerm_subnet.privatek8s_tier.name,
     azurerm_subnet.privatek8s_release_tier.name,
     azurerm_subnet.private_vnet_data_tier.name,
+    azurerm_subnet.privatek8s_infra_ci_controller_tier.name,
   ]
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4069

When we [migrated infra.ci.jenkins.io to `arm64`](https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2036372624), we [created a dedicated controller subnet](https://github.com/jenkins-infra/azure-net/pull/220) but we forgot to associate this subnet to the NAT gateway, resulting in using the LB (with SNAT) method for outbound connections instead of NAT gateway.

This PR corrects this by adding the subnet to the collection.