### PR TITLE
feat(gateways) add a second outbound IP to infra.ci agents/packers to spread outbound load

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -110,6 +110,8 @@ module "infra_ci_outbound_sponsorship" {
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.name,
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.name,
   ]
+
+  outbound_ip_count = 2
 }
 
 module "publick8s_outbound" {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4059

This PR aims at avoiding HTTP/429 errors on Chocolatey when building packer images in infra.ci.