### PR TITLE
feat(gateways) prepare ci.jenkins.io vnet for more agents (AKS)

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -81,6 +81,8 @@ module "ci_jenkins_io_outbound_sponsorship" {
     azurerm_subnet.ci_jenkins_io_controller_sponsorship.name,
     azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name,
   ]
+
+  outbound_ip_count = 2
 }
 
 module "privatek8s_outbound" {

--- a/gateways.tf
+++ b/gateways.tf
@@ -79,8 +79,7 @@ module "ci_jenkins_io_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.public_jenkins_sponsorship_vnet_ci_jenkins_io_agents.name,
     azurerm_subnet.ci_jenkins_io_controller_sponsorship.name,
-    ## TODO: uncomment once the subnet is created to avoid "not found" errors
-    # azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name,
+    azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name,
   ]
 }
 

--- a/gateways.tf
+++ b/gateways.tf
@@ -79,6 +79,8 @@ module "ci_jenkins_io_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.public_jenkins_sponsorship_vnet_ci_jenkins_io_agents.name,
     azurerm_subnet.ci_jenkins_io_controller_sponsorship.name,
+    ## TODO: uncomment once the subnet is created to avoid "not found" errors
+    # azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name,
   ]
 }
 

--- a/vnets.tf
+++ b/vnets.tf
@@ -278,6 +278,13 @@ resource "azurerm_subnet" "ci_jenkins_io_controller_sponsorship" {
   virtual_network_name = azurerm_virtual_network.public_jenkins_sponsorship.name
   address_prefixes     = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
 }
+resource "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_kubernetes"
+  resource_group_name  = azurerm_virtual_network.public_jenkins_sponsorship.resource_group_name
+  virtual_network_name = azurerm_virtual_network.public_jenkins_sponsorship.name
+  address_prefixes     = ["10.201.0.0/24"] # 10.201.0.0 - 10.201.0.254
+}
 
 # This subnet is reserved as "delegated" for the pgsql server on the public-db network
 # Ref. https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking


### PR DESCRIPTION
Blocked by #234

This PR ensures that the subnet (sponsored subscription) are ready to handle the new AKS cluster for ci.jenkins.io container agents with the following changes:

- Using a NAT gateway for outbound connections (requires the subnet to be created) as specified in https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2096296286
- Add a secondary public IP for outbound to spread the workload (and avoid potential HTTP/429 from DockerHub)