### PR TITLE
feat(vnets) add a new subnet for the ci.jenkins.io agents 1 AKS cluster

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -79,6 +79,8 @@ module "ci_jenkins_io_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.public_jenkins_sponsorship_vnet_ci_jenkins_io_agents.name,
     azurerm_subnet.ci_jenkins_io_controller_sponsorship.name,
+    ## TODO: uncomment once the subnet is created to avoid "not found" errors
+    # azurerm_subnet.ci_jenkins_io_kubernetes_sponsorship.name,
   ]
 }
 

--- a/vnets.tf
+++ b/vnets.tf
@@ -278,6 +278,13 @@ resource "azurerm_subnet" "ci_jenkins_io_controller_sponsorship" {
   virtual_network_name = azurerm_virtual_network.public_jenkins_sponsorship.name
   address_prefixes     = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
 }
+resource "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
+  provider             = azurerm.jenkins-sponsorship
+  name                 = "${azurerm_virtual_network.public_jenkins_sponsorship.name}-ci_jenkins_io_kubernetes"
+  resource_group_name  = azurerm_virtual_network.public_jenkins_sponsorship.resource_group_name
+  virtual_network_name = azurerm_virtual_network.public_jenkins_sponsorship.name
+  address_prefixes     = ["10.201.0.0/24"] # 10.201.0.0 - 10.201.0.254
+}
 
 # This subnet is reserved as "delegated" for the pgsql server on the public-db network
 # Ref. https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking


### PR DESCRIPTION
This PR adds a new subnet to support the new cluster described in https://github.com/jenkins-infra/helpdesk/issues/2649.

Notes:
- As per the [proposed network sizing](https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2096296286), the subnet is only a `/24` as we don't expected more than ~200 nodes and pods will have their own private CIDR.
  - Note we can grow this subnet for now if needed (vnet is a `/14` so we still have plenty of available ranges)
- The NAT gateway is not yet associated: it looks like the custom module does not like specifying a non existing subnet. I've opened https://github.com/jenkins-infra/azure-net/pull/233 for this when the subnet will be created