### PR TITLE
cleanup(DNS records) remove Digital Ocean Kubernetes cluster DNS records

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -120,20 +120,6 @@ resource "azurerm_dns_a_record" "ldap_jenkins_io" {
   })
 }
 
-# A record pointing to doks-public cluster public IPv4 address
-# Note: no IPv6 record as DO LB do not support them (mid-2023): https://docs.digitalocean.com/products/networking/load-balancers/details/limits/
-resource "azurerm_dns_a_record" "doks_public_public_ipv4_address" {
-  name                = "doks-public-public-ipv4-address"
-  zone_name           = data.azurerm_dns_zone.jenkinsio.name
-  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
-  ttl                 = 60
-  records             = [local.public_ips["doks_public_public_ipv4_address"]]
-
-  tags = merge(local.default_tags, {
-    purpose = "Public IPv4 address of doks-public cluster for common reference"
-  })
-}
-
 ## jenkinsistheway.io DNS zone records
 # Apex records for the jenkinsistheway.io redirector hosted on publick8s redirecting to stories.jenkins.io
 resource "azurerm_dns_a_record" "jenkinsistheway_io" {

--- a/locals.tf
+++ b/locals.tf
@@ -24,6 +24,5 @@ locals {
     "publick8s_public_ipv4_address"   = "20.7.178.24"          # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
     "publick8s_public_ipv6_address"   = "2603:1030:408:5::15a" # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
     "ldap_jenkins_io_ipv4_address"    = "20.7.180.148"         # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-    "doks_public_public_ipv4_address" = "157.245.23.55"        # defined in https://github.com/jenkins-infra/digitalocean/blob/main/doks-public-cluster.tf
   }
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954, this PR removes the leftover DNS records pointing to removed resources in DigitalOcean