### PR TITLE
feat: add report publication from local file to automate jenkins-infra-data extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 backend-config
 terraform-plan-output.txt
 tfplan
+jenkins-infra-data-reports/

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/862/head') _
+
 parallel(
   failFast: false,
   'terraform': {
@@ -28,6 +30,7 @@ parallel(
           variable: 'BACKEND_CONFIG_FILE',
         ),
       ],
+      publishReports: ['jenkins-infra-data-reports/azure-net.json'],
     )
   },
   'updatecli': {

--- a/locals.tf
+++ b/locals.tf
@@ -21,8 +21,8 @@ locals {
   }
 
   public_ips = {
-    "publick8s_public_ipv4_address"   = "20.7.178.24"          # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-    "publick8s_public_ipv6_address"   = "2603:1030:408:5::15a" # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-    "ldap_jenkins_io_ipv4_address"    = "20.7.180.148"         # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+    "publick8s_public_ipv4_address" = "20.7.178.24"          # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+    "publick8s_public_ipv6_address" = "2603:1030:408:5::15a" # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+    "ldap_jenkins_io_ipv4_address"  = "20.7.180.148"         # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,23 @@
-######################################################## Gateways Outbound IPs
-output "cert_ci_outbound_ips" {
-  value = module.cert_ci_jenkins_io_outbound.public_ip_list
+resource "local_file" "jenkins_infra_data_report" {
+  content = jsonencode({
+    "cert.ci.jenkins.io" = {
+      "outbound_ips" = concat(split(",", module.cert_ci_jenkins_io_outbound.public_ip_list), split(",", module.cert_ci_jenkins_io_outbound_sponsorship.public_ip_list)),
+    },
+    "trusted.ci.jenkins.io" = {
+      "outbound_ips" = concat(split(",", module.trusted_outbound.public_ip_list), split(",", module.trusted_outbound_sponsorship.public_ip_list)),
+    },
+    "ci.jenkins.io" = {
+      "outbound_ips" = concat(split(",", module.ci_jenkins_io_outbound.public_ip_list), split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list)),
+    },
+    "infra.ci.jenkins.io" = {
+      "outbound_ips" = concat(split(",", module.infra_ci_outbound_sponsorship.public_ip_list), split(",", module.privatek8s_outbound.public_ip_list)),
+    },
+    "privatek8s.jenkins.io" = {
+      "outbound_ips" = split(",", module.publick8s_outbound.public_ip_list),
+    },
+    "publick8s.jenkins.io" = {
+      "outbound_ips" = split(",", module.publick8s_outbound.public_ip_list),
+    },
+  })
+  filename = "${path.module}/jenkins-infra-data-reports/azure-net.json"
 }
-output "cert_ci_sponsorship_outbound_ip_list" {
-  value = module.cert_ci_jenkins_io_outbound_sponsorship.public_ip_list
-}
-output "trusted_ci_outbound_ip_list" {
-  value = module.trusted_outbound.public_ip_list
-}
-output "trusted_ci_sponsorship_outbound_ip_list" {
-  value = module.trusted_outbound_sponsorship.public_ip_list
-}
-output "ci_outbound_ip_list" {
-  value = module.ci_jenkins_io_outbound.public_ip_list
-}
-output "ci_sponsorship_outbound_ip_list" {
-  value = module.ci_jenkins_io_outbound_sponsorship.public_ip_list
-}
-output "infra_ci_outbound_ip_list" {
-  value = module.infra_ci_outbound_sponsorship.public_ip_list
-}
-output "publick8s_outbound_ip_list" {
-  value = module.publick8s_outbound.public_ip_list
-}
-output "privatek8s_outbound_ip_list" {
-  value = module.privatek8s_outbound.public_ip_list
-}
-##############################################################################

--- a/vnets.tf
+++ b/vnets.tf
@@ -158,7 +158,7 @@ resource "azurerm_virtual_network" "public_db" {
   name                = "${azurerm_resource_group.public.name}-db-vnet"
   location            = azurerm_resource_group.public.location
   resource_group_name = azurerm_resource_group.public.name
-  address_space       = ["10.253.0.0/21"] # 10.10.253.0.1 - 10.253.7.254
+  address_space       = ["10.253.0.0/21"] # 10.253.0.1 - 10.253.7.254
   tags                = local.default_tags
 }
 


### PR DESCRIPTION
Experiment related to https://github.com/jenkins-infra/helpdesk/issues/4114

It serves as a test case for https://github.com/jenkins-infra/pipeline-library/pull/862.

It introduces a new "local file" which replaces (**non sensitive**) outputs. This local file is in JSON and we want to publish it on each terraform apply on the main branch to reports.jenkins.io.
The goal is to automate the data extraction to a centralized place where we will be able to consume it (in this case: to retrieve the outbound IP and add them to the infra API)