### PR TITLE
feat(infraci/agents-sponsored/cluster): add new subnet to infra ci outbound ips in sponsored

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -112,6 +112,7 @@ module "infra_ci_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.name,
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.name,
+    azurerm_subnet.infra_ci_jenkins_io_kubernetes_agent_sponsorship.name,
   ]
 
   outbound_ip_count = 2


### PR DESCRIPTION
fix to failure of https://github.com/jenkins-infra/azure/pull/715
Plan: 2 to add, 0 to change, 0 to destroy.
1 json output
2 outbound azurerm_subnet_nat_gateway_association