### PR TITLE
Revert "feat(infraci/agents-sponsored/cluster): add new subnet to infra ci outbound ips in sponsored"

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -112,7 +112,6 @@ module "infra_ci_outbound_sponsorship" {
   subnet_names = [
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_ephemeral_agents.name,
     azurerm_subnet.infra_ci_jenkins_io_sponsorship_packer_builds.name,
-    azurerm_subnet.infra_ci_jenkins_io_kubernetes_agent_sponsorship.name,
   ]
 
   outbound_ip_count = 2


### PR DESCRIPTION
Reverts jenkins-infra/azure-net#250

As per https://github.com/jenkins-infra/azure/pull/715#issuecomment-2158813175, we have to rename the subnet, which will re-create it.

First, we need to remove the nat gateway association from the "soon to be deleted because name too long subnet" hence this PR