### PR TITLE
hotfix(vnets) shorten name for the infra.ci sponsored subnet used for kubernetes agents

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -287,7 +287,7 @@ resource "azurerm_subnet" "ci_jenkins_io_kubernetes_sponsorship" {
 }
 resource "azurerm_subnet" "infra_ci_jenkins_io_kubernetes_agent_sponsorship" {
   provider             = azurerm.jenkins-sponsorship
-  name                 = "${azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}-infraci_jenkins_io_kubernetes-agent"
+  name                 = "${azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}-kubernetes-agents"
   resource_group_name  = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.resource_group_name
   virtual_network_name = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name
   address_prefixes     = ["10.206.2.0/24"] # 10.206.2.0 - 10.206.2.254


### PR DESCRIPTION
This PR re-creates the subnet used for the infra.ci.jio Kubernetes agents (ref. ) with a shorter name:

`infra-ci-jenkins-io-sponsorship-vnet-kubernetes-agent` (53 chars) instead of `infra-ci-jenkins-io-sponsorship-vnet-infraci_jenkins_io_kubernetes-agent` (72 chars) to fix the error mentioned inhttps://github.com/jenkins-infra/azure/pull/715#issuecomment-2158813175

Of course it sets the name to a different convention than other subnets, but unless we want to recreate everything we don't have any solution: I chose to only rename the subnet to avoid recreating the whole vnet.