### PR TITLE
feat(vnets) enable Keyvault and Storage endpoints for infracijio-agents-1 subnet

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -291,6 +291,8 @@ resource "azurerm_subnet" "infra_ci_jenkins_io_kubernetes_agent_sponsorship" {
   resource_group_name  = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.resource_group_name
   virtual_network_name = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name
   address_prefixes     = ["10.206.2.0/24"] # 10.206.2.0 - 10.206.2.254
+  # Enable KeyVault and Storage service endpoints so agents can access Storage Account through internal routes + secrets
+  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
 }
 
 # This subnet is reserved as "delegated" for the pgsql server on the public-db network


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3923, this PR enable Azure Network endpoints for KeyVaults and Storage on the subnet used by the infracijio-agents-1 cluster.

Note: we also need to add the parent vnet in the allowed vnets of the keyvault for infra.ci