### PR TITLE
hotfix(vnets) add peering between infracijio-agents-1 and public-db

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -399,12 +399,32 @@ resource "azurerm_virtual_network_peering" "public_sponsorship_to_infraci_jenkin
   allow_gateway_transit        = false
   use_remote_gateways          = false
 }
-
 resource "azurerm_virtual_network_peering" "public_to_public_db" {
   name                         = "${azurerm_virtual_network.public.name}-to-${azurerm_virtual_network.public_db.name}"
   resource_group_name          = azurerm_virtual_network.public.resource_group_name
   virtual_network_name         = azurerm_virtual_network.public.name
   remote_virtual_network_id    = azurerm_virtual_network.public_db.id
+  allow_virtual_network_access = true
+  allow_forwarded_traffic      = false
+  allow_gateway_transit        = false
+  use_remote_gateways          = false
+}
+resource "azurerm_virtual_network_peering" "public_db_to_infraci_jenkins_sponsorship" {
+  provider                     = azurerm.jenkins-sponsorship
+  name                         = "${azurerm_virtual_network.public_db.name}-to-${azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}"
+  resource_group_name          = azurerm_virtual_network.public_db.resource_group_name
+  virtual_network_name         = azurerm_virtual_network.public_db.name
+  remote_virtual_network_id    = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.id
+  allow_virtual_network_access = true
+  allow_forwarded_traffic      = false
+  allow_gateway_transit        = false
+  use_remote_gateways          = false
+}
+resource "azurerm_virtual_network_peering" "infraci_jenkins_sponsorship_to_public_db" {
+  name                         = "${azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name}-to-${azurerm_virtual_network.public_db.name}"
+  resource_group_name          = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.resource_group_name
+  virtual_network_name         = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.name
+  remote_virtual_network_id    = azurerm_virtual_network.infra_ci_jenkins_io_sponsorship.id
   allow_virtual_network_access = true
   allow_forwarded_traffic      = false
   allow_gateway_transit        = false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3923

Blocks https://github.com/jenkins-infra/azure/pull/746

Since https://github.com/jenkins-infra/kubernetes-management/pull/5342, the terraform agents are running in a different network which need to access the postgreSQL vnet.