### PR TITLE
feat(gateways) set release.ci.jenkins.io controller subnet to use the private outbound gateway (instead of AKS LB)

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -100,8 +100,7 @@ module "privatek8s_outbound" {
     module.private_vnet.subnets["privatek8s-release-tier"],
     module.private_vnet.subnets["private-vnet-data-tier"],
     module.private_vnet.subnets["privatek8s-infraci-ctrl-tier"],
-    ## TODO: uncomment to move release.ci controller under the NAT gateway outbound method
-    # module.private_vnet.subnets["privatek8s-releaseci-ctrl-tier"],
+    module.private_vnet.subnets["privatek8s-releaseci-ctrl-tier"],
   ]
 }
 


### PR DESCRIPTION
Caught while working on #268 

This PR effectively changes the outbound IP of the release.ci.jenkins.io controller from the `privatek8s`'s LB outbound IPs (`20.22.6.81`) to the `private_vnet` NAT gateway outbound IP (`20.65.63.127`).

No issue expected:

- LDAP is already setup (for infra.ci.jenkins.io) to accept the NAT outbound IP (ref. https://github.com/jenkins-infra/kubernetes-management/blob/187b0bb92620c23f774697ad56d56c51a3925255/config/ldap.yaml#L25C8-L25C20)