### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+properties([pipelineTriggers([cron('@daily')])])
+
 terraform(
   stagingCredentials: [
     azureServicePrincipal(

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,4 +1,7 @@
-properties([pipelineTriggers([cron('@daily')])])
+if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+}
 
 terraform(
   stagingCredentials: [

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,40 +1,29 @@
-parallel(
-  failFast: false,
-  'terraform': {
-    terraform(
-      stagingCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'staging-terraform-azure-net-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'staging-terraform-azure-net-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-      productionCredentials: [
-        azureServicePrincipal(
-          credentialsId: 'production-terraform-azure-net-serviceprincipal',
-          subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
-          clientIdVariable: 'ARM_CLIENT_ID',
-          clientSecretVariable: 'ARM_CLIENT_SECRET',
-          tenantIdVariable: 'ARM_TENANT_ID',
-        ),
-        file(
-          credentialsId: 'production-terraform-azure-net-backend-config',
-          variable: 'BACKEND_CONFIG_FILE',
-        ),
-      ],
-      publishReports: ['jenkins-infra-data-reports/azure-net.json'],
-    )
-  },
-  'updatecli': {
-    updatecli(action: 'diff')
-    if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@daily')
-    }
-  },
+terraform(
+  stagingCredentials: [
+    azureServicePrincipal(
+      credentialsId: 'staging-terraform-azure-net-serviceprincipal',
+      subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+      clientIdVariable: 'ARM_CLIENT_ID',
+      clientSecretVariable: 'ARM_CLIENT_SECRET',
+      tenantIdVariable: 'ARM_TENANT_ID',
+    ),
+    file(
+      credentialsId: 'staging-terraform-azure-net-backend-config',
+      variable: 'BACKEND_CONFIG_FILE',
+    ),
+  ],
+  productionCredentials: [
+    azureServicePrincipal(
+      credentialsId: 'production-terraform-azure-net-serviceprincipal',
+      subscriptionIdVariable: 'ARM_SUBSCRIPTION_ID',
+      clientIdVariable: 'ARM_CLIENT_ID',
+      clientSecretVariable: 'ARM_CLIENT_SECRET',
+      tenantIdVariable: 'ARM_TENANT_ID',
+    ),
+    file(
+      credentialsId: 'production-terraform-azure-net-backend-config',
+      variable: 'BACKEND_CONFIG_FILE',
+    ),
+  ],
+  publishReports: ['jenkins-infra-data-reports/azure-net.json'],
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+}

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,6 @@
+properties([pipelineTriggers([cron('@daily')])])
+
 updatecli(action: 'diff')
 if (env.BRANCH_IS_PRIMARY) {
-    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+    updatecli(action: 'apply')
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,6 +1,7 @@
-properties([pipelineTriggers([cron('@daily')])])
-
 updatecli(action: 'diff')
+
 if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
     updatecli(action: 'apply')
 }

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778