### PR TITLE
feat(cert.ci): add an outbound ip for cert ephemeral agents on sponsored account

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -27,6 +27,8 @@ module "cert_ci_jenkins_io_outbound_sponsorship" {
   subnet_ids = [
     module.cert_ci_jenkins_io_sponsorship_vnet.subnets["cert-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"],
   ]
+
+  outbound_ip_count = 2
 }
 
 module "trusted_outbound" {


### PR DESCRIPTION
as per @daniel-beck information, outbound connexion from cert.ci agents is sometimes unable to join github.com. This new IP will help to spread the load.

Plan: 3 to add, 0 to change, 0 to destroy.