### PR TITLE
feat(gateways) increase amount of outbound IPs for ci.jenkins.io agents to spread egress workloads

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -88,7 +88,7 @@ module "ci_jenkins_io_outbound_sponsorship" {
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"],
   ]
 
-  outbound_ip_count = 2
+  outbound_ip_count = 4
 }
 
 module "privatek8s_outbound" {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2262377024

This PR is a short term fix to unblock ci.jenkins.io builds stuck with DockerHub `HTTP/429 toomanyrequests` HTTP errors when pulling images.
