### PR TITLE
feat(vnets) allow keyvault endpoint for ci.jenkins.io controller and VM agents

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -185,13 +185,13 @@ module "public_sponsorship_vnet" {
     {
       name              = "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
       address_prefixes  = ["10.200.2.0/24"] # 10.200.2.1 - 10.200.2.254
-      service_endpoints = []
+      service_endpoints = ["Microsoft.KeyVault"]
       delegations       = {}
     },
     {
       name              = "public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"
       address_prefixes  = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
-      service_endpoints = []
+      service_endpoints = ["Microsoft.KeyVault"]
       delegations       = {}
     },
     {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2263339493

This PR ensures that both controller and VM agents (ci.jenkins.io) can access the keyvault through subnet endpoints