### PR TITLE
feat(vnets) add a new dedicated subnet for ci.jenkins.io ACI agents

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -86,6 +86,7 @@ module "ci_jenkins_io_outbound_sponsorship" {
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"],
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"],
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"],
+    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"],
   ]
 
   outbound_ip_count = 4

--- a/vnets.tf
+++ b/vnets.tf
@@ -189,6 +189,19 @@ module "public_sponsorship_vnet" {
       delegations       = {}
     },
     {
+      name              = "public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"
+      address_prefixes  = ["10.200.3.0/24"] # 10.200.3.1 - 10.200.3.254
+      service_endpoints = []
+      delegations = {
+        "aci" = {
+          service_delegations = [{
+            name    = "Microsoft.ContainerInstance/containerGroups"
+            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action", "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action"]
+          }]
+        }
+      }
+    },
+    {
       name              = "public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"
       address_prefixes  = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
       service_endpoints = []


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2281268067

This PR adds a new subnet dedicated for ACI agents on ci.jenkins.io.

ACI agents are currently using the default network setup, e.g. using a public IP.
As such, they are unable to reach the private ACP.

As per the plugin documentation (see below) using a private IP requires a dedicated subnet with a [delegation](https://learn.microsoft.com/en-us/azure/virtual-network/manage-subnet-delegation?tabs=manage-subnet-delegation-portal) to ACI service.

<img width="1245" alt="Capture d’écran 2024-08-10 à 14 06 26" src="https://github.com/user-attachments/assets/77750e16-9644-4190-8070-aafac3085861">


It means we cannot share the existing subnet used for Azure VM agents: we need a new subnet in the same vnet (to keep using the same NSG and private DNS endpoints).