### PR TITLE
feat(dns) import and add DNS records for updates.jenkins.io

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -196,7 +196,7 @@ module "public_sponsorship_vnet" {
         "aci" = {
           service_delegations = [{
             name    = "Microsoft.ContainerInstance/containerGroups"
-            actions = ["Microsoft.Network/virtualNetworks/subnets/join/action", "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action"]
+            actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
           }]
         }
       }


### PR DESCRIPTION
Prerequisite for the Update Center brownout 1 (see https://github.com/jenkins-infra/helpdesk/issues/2649)

It adds a new `A` DNS record `aws.updates` so it will be easy to defined a `CNAME` pointing to it (and changing the CNAME when needed for brownouts).

It also imports and updates a few existing records.

Notes: 

- Cleanup a non-idempotent change in vnets (delegation) to use the correct action applied by Azure ACI backens
- Import records which are currently defined in jenkins-infra/azure. Need a PR to remove them. Rationale is that using CNAME here ensure operation safety (that is the purpose of the whole repository) of top-level items.
- The plan shows a "removed dot" for the 2 imported records. It's because we used the `FQDN` to populate it. Like the other records in the loop here, its FQDN will have the trailing dot in the resulting FQDN generated by the plugin (ref. https://github.com/hashicorp/terraform-provider-azurerm/issues/6758). Yeah weird API...


