### PR TITLE
Revert "feat(DNS records) UC brownout 3: switch to AKS hosted service"

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -79,7 +79,7 @@ resource "azurerm_dns_cname_record" "updates_jenkins_io" {
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
-  record              = "azure.updates.jenkins.io"
+  record              = "aws.updates.jenkins.io"
 
   tags = merge(local.default_tags, {
     purpose = "Jenkins Update Center"


### PR DESCRIPTION
Reverts jenkins-infra/azure-net#292

Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2343052172

End of the third brownout