### PR TITLE
chore: fix trivy 0.55.x false positive errors

### DIFF
--- a/vpn.tf
+++ b/vpn.tf
@@ -67,6 +67,8 @@ resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_vpn" {
   network_security_group_name = azurerm_network_security_group.private_dmz.name
 }
 
+## Do not tag internet ingress as a security issue (we want VPN to be available through internet)
+#trivy:ignore:avd-azu-0047
 resource "azurerm_network_security_rule" "allow_openvpn_from_internet_to_vpn" {
   name                        = "allow-openvpn-from-internet-to-vpn"
   priority                    = 200
@@ -97,6 +99,8 @@ resource "azurerm_network_security_rule" "allow_puppet_from_vpn_to_puppetmasters
   network_security_group_name = azurerm_network_security_group.private_dmz.name
 }
 
+## Do not tag internet egress as a security issue
+#trivy:ignore:avd-azu-0051
 resource "azurerm_network_security_rule" "allow_https_from_vpn_to_Internet" {
   name                        = "allow-https-from-vpn-to-Internet"
   priority                    = 2200


### PR DESCRIPTION
Since https://github.com/aquasecurity/trivy/blob/main/CHANGELOG.md#0550-2024-09-03 (with https://github.com/jenkins-infra/packer-images/releases/tag/2.1.0) , `trivy` throw false positives.

This PR ignores these errors, along with https://github.com/jenkins-infra/shared-tools/commit/448f09d29e964c0aaef6ef7e9fe272669d09462e