### PR TITLE
feat(DNS records) switch Update Center to Azure

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -79,7 +79,7 @@ resource "azurerm_dns_cname_record" "updates_jenkins_io" {
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
-  record              = "aws.updates.jenkins.io"
+  record              = "azure.updates.jenkins.io"
 
   tags = merge(local.default_tags, {
     purpose = "Jenkins Update Center"


### PR DESCRIPTION
This PR starts the [fourth Update Center brownout](https://www.jenkins.io/blog/2024/09/25/update-center-brownouts-4/) as per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995