### PR TITLE
fix(updatecli): Improve PR titles for Azure SP expired credentials

### DIFF
--- a/updatecli/updatecli.d/letsencrypt_cert.ci.yaml
+++ b/updatecli/updatecli.d/letsencrypt_cert.ci.yaml
@@ -56,7 +56,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure Service Principal password on `cert.ci.jenkins.io - Let's Encrypt`
+      title: Generate a new Azure Service Principal password on `cert.ci.jenkins.io - Let's Encrypt` expired on {{ source "currentExpiryCert" }}
       description: "Generate a new password for the Azure Service Principal `cert.ci.jenkins.io - Let's Encrypt`. Set the new password value in the following encrypted file: <https://github.com/jenkins-infra/jenkins-infra/blob/d76e72a6c1ee06a0d321ed4d04c5d3e1b81d061d/hieradata/clients/controller.cert.ci.jenkins.io.yaml#L27> (open a PR: https://github.com/jenkins-infra/jenkins-infra/edit/production/hieradata/clients/controller.cert.ci.jenkins.io.yaml)."
       labels:
         - terraform

--- a/updatecli/updatecli.d/letsencrypt_cert.ci.yaml
+++ b/updatecli/updatecli.d/letsencrypt_cert.ci.yaml
@@ -56,7 +56,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure Service Principal password with expiration date {{ source "nextExpiry" }} on `cert.ci.jenkins.io`
+      title: Generate a new Azure Service Principal password on `cert.ci.jenkins.io - Let's Encrypt`
       description: "Generate a new password for the Azure Service Principal `cert.ci.jenkins.io - Let's Encrypt`. Set the new password value in the following encrypted file: <https://github.com/jenkins-infra/jenkins-infra/blob/d76e72a6c1ee06a0d321ed4d04c5d3e1b81d061d/hieradata/clients/controller.cert.ci.jenkins.io.yaml#L27> (open a PR: https://github.com/jenkins-infra/jenkins-infra/edit/production/hieradata/clients/controller.cert.ci.jenkins.io.yaml)."
       labels:
         - terraform

--- a/updatecli/updatecli.d/letsencrypt_trusted.ci.yaml
+++ b/updatecli/updatecli.d/letsencrypt_trusted.ci.yaml
@@ -56,7 +56,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure Service Principal password with expiration date {{ source "nextExpiry" }} on `trusted.ci.jenkins.io`
+      title: Generate a new Azure Service Principal password on `trusted.ci.jenkins.io - Let's Encrypt`
       description: "Generate a new password for the Azure Service Principal `trusted.ci.jenkins.io - Let's Encrypt`. Set the new password value in the following encrypted file: <https://github.com/jenkins-infra/jenkins-infra/blob/48cccaf73204026274c783da5a8f22db1b2c18bb/hieradata/clients/controller.trusted.ci.jenkins.io.yaml#L32> (open a PR: https://github.com/jenkins-infra/jenkins-infra/edit/production/hieradata/clients/controller.trusted.ci.jenkins.io.yaml)."
       labels:
         - terraform

--- a/updatecli/updatecli.d/letsencrypt_trusted.ci.yaml
+++ b/updatecli/updatecli.d/letsencrypt_trusted.ci.yaml
@@ -56,7 +56,7 @@ actions:
     kind: github/pullrequest
     scmid: default
     spec:
-      title: Generate a new Azure Service Principal password on `trusted.ci.jenkins.io - Let's Encrypt`
+      title: Generate a new Azure Service Principal password on `trusted.ci.jenkins.io - Let's Encrypt` expired on {{ source "currentExpiryTrusted" }}
       description: "Generate a new password for the Azure Service Principal `trusted.ci.jenkins.io - Let's Encrypt`. Set the new password value in the following encrypted file: <https://github.com/jenkins-infra/jenkins-infra/blob/48cccaf73204026274c783da5a8f22db1b2c18bb/hieradata/clients/controller.trusted.ci.jenkins.io.yaml#L32> (open a PR: https://github.com/jenkins-infra/jenkins-infra/edit/production/hieradata/clients/controller.trusted.ci.jenkins.io.yaml)."
       labels:
         - terraform


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4301#issue-2544767482

This PR improves the PR titles generated by updatecli for expire Azure SP credentials.

We now only include the scope of the PR and the current exp date in the PR title.