### PR TITLE
feat(DNS records) close fifth brownout of the Update Center

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -118,7 +118,7 @@ resource "azurerm_dns_cname_record" "updates_jenkins_io" {
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
-  record              = "azure.updates.jenkins.io"
+  record              = "aws.updates.jenkins.io"
 
   tags = merge(local.default_tags, {
     purpose = "Jenkins Update Center"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2434782765

This PR reverts https://github.com/jenkins-infra/azure-net/pull/306 to close the fifth brownout for the Update Center.

It should be merged at 10:00am UTC Friday 25 October 2024