### PR TITLE
chore(outputs) fixes the private.vpn outbound ip type

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -26,7 +26,7 @@ resource "local_file" "jenkins_infra_data_report" {
     },
     "private.vpn.jenkins.io" = {
       # VPN VM uses its public IP as outbound method (default Azure behavior) instead of the outbound NAT gateway
-      "outbound_ips" = azurerm_public_ip.vpn_public.ip_address,
+      "outbound_ips" = [azurerm_public_ip.vpn_public.ip_address],
     },
     "vnets" = {
       "cert-ci-jenkins-io-sponsorship-vnet"    = module.cert_ci_jenkins_io_sponsorship_vnet.vnet_address_space,


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/34

This PR fixes the private.vpn outbound ip type to array so there is feature parity with all the outbound ips listed on the azure-net json report.