### PR TITLE
feat(DNS) delegate 'aws.ci.jenkins.io' subdomain to AWS route53

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -42,6 +42,23 @@ resource "azurerm_dns_ns_record" "do_jenkins_io" {
   tags = local.default_tags
 }
 
+# NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them$
+resource "azurerm_dns_ns_record" "aws_ci_jenkins_io" {
+  name                = "aws.ci"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
+
+  records = [
+    "ns-103.awsdns-12.com",
+    "ns-1131.awsdns-13.org",
+    "ns-1760.awsdns-28.co.uk",
+    "ns-573.awsdns-07.net",
+  ]
+
+  tags = local.default_tags
+}
+
 resource "azurerm_dns_zone" "child_zones" {
   for_each = local.lets_encrypt_dns_challenged_domains
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4320

This PR adds NS records for `aws.ci.jenkins.io` subdomain to delegate DNS to Route 53 and ensure the records are always up to date.


Note: a subsequent PR will be requried to keep the route 53 name servers up to date here as I manually cherry picked their values by hand this time