### PR TITLE
chore(updatecli/dns) track NS for aws.ci.jenkins.io

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -42,19 +42,18 @@ resource "azurerm_dns_ns_record" "do_jenkins_io" {
   tags = local.default_tags
 }
 
-# NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them$
+# NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them
+locals {
+  # Tracked by updatecli, easier to use a string split as a list by Terraform
+  aws_route53_nameservers_awscijenkinsio = "ns-103.awsdns-12.com ns-1131.awsdns-13.org ns-1760.awsdns-28.co.uk ns-573.awsdns-07.net"
+}
 resource "azurerm_dns_ns_record" "aws_ci_jenkins_io" {
   name                = "aws.ci"
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 60
 
-  records = [
-    "ns-103.awsdns-12.com",
-    "ns-1131.awsdns-13.org",
-    "ns-1760.awsdns-28.co.uk",
-    "ns-573.awsdns-07.net",
-  ]
+  records = split(" ", local.aws_route53_nameservers_awscijenkinsio)
 
   tags = local.default_tags
 }

--- a/updatecli/updatecli.d/aws-dns-ns.yaml
+++ b/updatecli/updatecli.d/aws-dns-ns.yaml
@@ -1,0 +1,51 @@
+name: Track the AWS Route53 DNS Zone Name Servers for delegated zones
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getAwsCiJenkinsIoNameServers:
+    name: Get the Name Servers of the AWS Route 53 aws.ci.jenkins.io DNS zone
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.name_servers
+
+targets:
+  updateNSRecord:
+    name: Update NS records for aws.ci.jenkins.io
+    kind: hcl
+    sourceid: getAwsCiJenkinsIoNameServers
+    transformers:
+      - replacers:
+          - from: '['
+            to: ''
+          - from: ']'
+            to: ''
+    spec:
+      file: ./dns.tf
+      path: locals.aws_route53_nameservers_awscijenkinsio
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Update NS records for aws.ci.jenkins.io to {{ source "getAwsCiJenkinsIoNameServers" }}
+      description: |
+        A new set of Name Servers for the AWS Route 53 delegated zone for `aws.ci.jenkins.io` were detected in <https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json>.
+        This PR updates the `NS` records with the new detected values.
+      labels:
+        - terraform
+        - dns
+        - aws.ci.jenkins.io


### PR DESCRIPTION
Follow up of #370, related to https://github.com/jenkins-infra/helpdesk/issues/4315

Now that we have a [report](https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json) for the AWS Terraform project (ref. https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/36), we have to track changes made to the Route53 AWS zone for `aws.ci.jenkins.io`.

This is the goal of this PR.

Note: `updatecli` check is expected to fail, but was tested locally with the target's `scmid` atrribute commented out, with success.

