### PR TITLE
Update NS records for aws.ci.jenkins.io

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -45,7 +45,7 @@ resource "azurerm_dns_ns_record" "do_jenkins_io" {
 # NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them
 locals {
   # Tracked by updatecli, easier to use a string split as a list by Terraform
-  aws_route53_nameservers_awscijenkinsio = "ns-103.awsdns-12.com ns-1131.awsdns-13.org ns-1760.awsdns-28.co.uk ns-573.awsdns-07.net"
+  aws_route53_nameservers_awscijenkinsio = "ns-1378.awsdns-44.org ns-1925.awsdns-48.co.uk ns-508.awsdns-63.com ns-592.awsdns-10.net"
 }
 resource "azurerm_dns_ns_record" "aws_ci_jenkins_io" {
   name                = "aws.ci"


### PR DESCRIPTION



<Actions>
    <action id="da68fa1d5caa75df1bf831f7626df254812a4a19dbf3320e1ec15e3c04800650">
        <h3>Track the AWS Route53 DNS Zone Name Servers for delegated zones</h3>
        <details id="c014258ed429115cf5bc02138cf65474a9e7f5e1f95a38b8c955368b16709a5f">
            <summary>Update NS records for aws.ci.jenkins.io</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.aws_route53_nameservers_awscijenkinsio&#34; updated from &#34;ns-103.awsdns-12.com ns-1131.awsdns-13.org ns-1760.awsdns-28.co.uk ns-573.awsdns-07.net&#34; to &#34;ns-1378.awsdns-44.org ns-1925.awsdns-48.co.uk ns-508.awsdns-63.com ns-592.awsdns-10.net&#34; in file &#34;dns.tf&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

