### PR TITLE
feat(dns/jenkins.io) allow google workpace in SPF

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -376,7 +376,7 @@ resource "azurerm_dns_txt_record" "apex_jenkinsio" {
     value = "google-site-verification=4Z81CA6VzprPWEbGFtNbJwWoZBTGmTp3dk7N0hbt87U"
   }
   record {
-    value = "v=spf1 include:mailgun.org include:sendgrid.net -all"
+    value = "v=spf1 include:mailgun.org include:sendgrid.net include:_spf.google.com ~all"
   }
 
   tags = local.default_tags


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3089

- Allow Google Workpasce to send emails to unblock @Wadeck , from https://support.google.com/a/answer/33786?hl=fr&visit_id=638731413171831433-758340368&rd=1#zippy=%2Cexemples-denregistrements-spf
- Set the SPF to `~all` to mark email failing SPF as anti spam (with high score) instead of rejecting