### PR TITLE
feat(vnets/gateways) re-create ci.jenkins.io resources in the sponsored subscription

### DIFF
--- a/gateways.tf
+++ b/gateways.tf
@@ -60,6 +60,38 @@ module "trusted_outbound_sponsorship" {
   outbound_ip_count = 3
 }
 
+module "ci_jenkins_io_outbound" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  name                = "ci-jenkins-io-outbound"
+  resource_group_name = module.public_vnet.vnet_rg_name
+  vnet_name           = module.public_vnet.vnet_name
+  subnet_ids = [
+    module.public_vnet.subnets["public-vnet-ci_jenkins_io_controller"],
+    module.public_vnet.subnets["public-vnet-ci_jenkins_io_agents"],
+  ]
+}
+
+module "ci_jenkins_io_outbound_sponsorship" {
+  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+
+  providers = {
+    azurerm = azurerm.jenkins-sponsorship
+  }
+
+  name                = "ci-jenkins-io-outbound-sponsorship"
+  resource_group_name = module.public_sponsorship_vnet.vnet_rg_name
+  vnet_name           = module.public_sponsorship_vnet.vnet_name
+  subnet_ids = [
+    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"],
+    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"],
+    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"],
+    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"],
+  ]
+
+  outbound_ip_count = 4
+}
+
 module "privatek8s_outbound" {
   source = "./.shared-tools/terraform/modules/azure-nat-gateway"
 

--- a/gateways.tf
+++ b/gateways.tf
@@ -61,7 +61,8 @@ module "trusted_outbound_sponsorship" {
 }
 
 module "ci_jenkins_io_outbound_sponsorship" {
-  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
+  depends_on = [module.public_sponsorship_vnet]
+  source     = "./.shared-tools/terraform/modules/azure-nat-gateway"
 
   providers = {
     azurerm = azurerm.jenkins-sponsorship

--- a/gateways.tf
+++ b/gateways.tf
@@ -60,18 +60,6 @@ module "trusted_outbound_sponsorship" {
   outbound_ip_count = 3
 }
 
-module "ci_jenkins_io_outbound" {
-  source = "./.shared-tools/terraform/modules/azure-nat-gateway"
-
-  name                = "ci-jenkins-io-outbound"
-  resource_group_name = module.public_vnet.vnet_rg_name
-  vnet_name           = module.public_vnet.vnet_name
-  subnet_ids = [
-    module.public_vnet.subnets["public-vnet-ci_jenkins_io_controller"],
-    module.public_vnet.subnets["public-vnet-ci_jenkins_io_agents"],
-  ]
-}
-
 module "ci_jenkins_io_outbound_sponsorship" {
   source = "./.shared-tools/terraform/modules/azure-nat-gateway"
 
@@ -86,10 +74,9 @@ module "ci_jenkins_io_outbound_sponsorship" {
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"],
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"],
     module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"],
-    module.public_sponsorship_vnet.subnets["public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"],
   ]
 
-  outbound_ip_count = 4
+  outbound_ip_count = 2
 }
 
 module "privatek8s_outbound" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ resource "local_file" "jenkins_infra_data_report" {
       "outbound_ips" = concat(split(",", module.trusted_outbound.public_ip_list), split(",", module.trusted_outbound_sponsorship.public_ip_list)),
     },
     "ci.jenkins.io" = {
-      "outbound_ips" = concat(split(",", module.ci_jenkins_io_outbound.public_ip_list), split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list)),
+      "outbound_ips" = split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list),
     },
     "infra.ci.jenkins.io" = {
       "outbound_ips" = concat(split(",", module.infra_ci_outbound_sponsorship.public_ip_list), split(",", module.privatek8s_outbound.public_ip_list)),

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,9 @@ resource "local_file" "jenkins_infra_data_report" {
     "trusted.ci.jenkins.io" = {
       "outbound_ips" = concat(split(",", module.trusted_outbound.public_ip_list), split(",", module.trusted_outbound_sponsorship.public_ip_list)),
     },
+    "ci.jenkins.io" = {
+      "outbound_ips" = concat(split(",", module.ci_jenkins_io_outbound.public_ip_list), split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list)),
+    },
     "infra.ci.jenkins.io" = {
       "outbound_ips" = concat(split(",", module.infra_ci_outbound_sponsorship.public_ip_list), split(",", module.privatek8s_outbound.public_ip_list)),
     },
@@ -15,6 +18,9 @@ resource "local_file" "jenkins_infra_data_report" {
     "publick8s.jenkins.io" = {
       "outbound_ips" = split(",", module.publick8s_outbound.public_ip_list),
     },
+    "cijenkinsioagents1.jenkins.io" = {
+      "outbound_ips" = split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list),
+    }
     "infracijenkinsioagents1.jenkins.io" = {
       "outbound_ips" = split(",", module.infra_ci_outbound_sponsorship.public_ip_list),
     },
@@ -28,6 +34,7 @@ resource "local_file" "jenkins_infra_data_report" {
       "infra-ci-jenkins-io-sponsorship-vnet"   = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_address_space,
       "private-vnet"                           = module.private_vnet.vnet_address_space,
       "public-db-vnet"                         = module.public_db_vnet.vnet_address_space,
+      "public-jenkins-sponsorship-vnet"        = module.public_sponsorship_vnet.vnet_address_space,
       "public-vnet"                            = module.public_vnet.vnet_address_space,
       "trusted-ci-jenkins-io-sponsorship-vnet" = module.trusted_ci_jenkins_io_sponsorship_vnet.vnet_address_space,
       "trusted-ci-jenkins-io-vnet"             = module.trusted_ci_jenkins_io_vnet.vnet_address_space,

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,9 +18,6 @@ resource "local_file" "jenkins_infra_data_report" {
     "publick8s.jenkins.io" = {
       "outbound_ips" = split(",", module.publick8s_outbound.public_ip_list),
     },
-    "cijenkinsioagents1.jenkins.io" = {
-      "outbound_ips" = split(",", module.ci_jenkins_io_outbound_sponsorship.public_ip_list),
-    }
     "infracijenkinsioagents1.jenkins.io" = {
       "outbound_ips" = split(",", module.infra_ci_outbound_sponsorship.public_ip_list),
     },

--- a/vnets.tf
+++ b/vnets.tf
@@ -76,36 +76,12 @@ module "public_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = false
       private_endpoint_network_policies             = "Enabled"
-    }
-    ,
-    {
-      # Dedicated subnets for ci.jenkins.io (controller and agents)
-      name                                          = "public-vnet-ci_jenkins_io_agents"
-      address_prefixes                              = ["10.245.2.0/23"] # 10.245.2.1 - 10.245.3.254
-      service_endpoints                             = []
-      delegations                                   = {}
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-    }
-    ,
-    {
-      # Dedicated subnets for ci.jenkins.io (controller and agents)
-      name = "public-vnet-ci_jenkins_io_controller"
-      address_prefixes = [
-        "10.245.4.0/24", # 10.245.4.1 - 10.245.4.254
-        "fd00:db8:deca::/64",
-      ]
-      service_endpoints                             = []
-      delegations                                   = {}
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-    }
+    },
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"            = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}"          = module.public_db_vnet.vnet_id,
-    "${module.public_sponsorship_vnet.vnet_name}" = module.public_sponsorship_vnet.vnet_id,
+    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
   }
 }
 
@@ -183,7 +159,6 @@ module "private_vnet" {
   peered_vnets = {
     "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}"                       = module.public_db_vnet.vnet_id,
-    "${module.public_sponsorship_vnet.vnet_name}"              = module.public_sponsorship_vnet.vnet_id,
     "${module.cert_ci_jenkins_io_vnet.vnet_name}"              = module.cert_ci_jenkins_io_vnet.vnet_id
     "${module.trusted_ci_jenkins_io_vnet.vnet_name}"           = module.trusted_ci_jenkins_io_vnet.vnet_id
     "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
@@ -211,21 +186,6 @@ module "public_sponsorship_vnet" {
       private_endpoint_network_policies             = "Disabled"
     },
     {
-      name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"
-      address_prefixes                              = ["10.200.3.0/24"] # 10.200.3.1 - 10.200.3.254
-      service_endpoints                             = []
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-      delegations = {
-        "aci" = {
-          service_delegations = [{
-            name    = "Microsoft.ContainerInstance/containerGroups"
-            actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-          }]
-        }
-      }
-    },
-    {
       name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"
       address_prefixes                              = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
       service_endpoints                             = []
@@ -244,8 +204,9 @@ module "public_sponsorship_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"                         = module.private_vnet.vnet_id,
-    "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id,
+    # Accesses through VPN and privatek8s cluster
+    "${module.private_vnet.vnet_name}" = module.private_vnet.vnet_id,
+    # Accesses through the infra.ci agents private vnet
     "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id,
   }
 }

--- a/vnets.tf
+++ b/vnets.tf
@@ -2,13 +2,13 @@
 # Networks in Azure according to IEP-002:
 #   <https://github.com/jenkins-infra/iep/tree/master/iep-002>
 #
-#                                                  ┌────────────────┐
-#                ┌───────────────────────┐         │                │
-#                │                       │         │                │
-#      ┌─────────►   Public VPN Gateway  ◄─────────►  Public VNet   │
-#      │         │                       │         │                │
-#      │         └───────────────────────┘         │   IPv4 + IPv6  │◄───────────────────┐
-#      │                                           └─▲──────────▲───┘     Vnet peering   │
+#                                                  ┌────────────────┐                              ┌───────────────────────────┐
+#                ┌───────────────────────┐         │                │                              │                           │
+#                │                       │         │                │                              │                           │
+#      ┌─────────►   Public VPN Gateway  ◄─────────►  Public VNet   ◄─────────────────────────────►│  Public-Sponsored Vnet    │
+#      │         │                       │         │                │          VNet peering        │                           │
+#      │         └───────────────────────┘         │   IPv4 + IPv6  │◄───────────────────┐         │                           │
+#      │                                           └─▲──────────▲───┘     Vnet peering   │         └───────────────────────────┘
 #      │                                             │          │                        │
 #                                                    │          │                        │
 #  The Internet ─────────────────────────────────────┘    VNet peering             ┌─────▼──────────────┐
@@ -77,11 +77,35 @@ module "public_vnet" {
       private_link_service_network_policies_enabled = false
       private_endpoint_network_policies             = "Enabled"
     }
+    ,
+    {
+      # Dedicated subnets for ci.jenkins.io (controller and agents)
+      name                                          = "public-vnet-ci_jenkins_io_agents"
+      address_prefixes                              = ["10.245.2.0/23"] # 10.245.2.1 - 10.245.3.254
+      service_endpoints                             = []
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = true
+      private_endpoint_network_policies             = "Enabled"
+    }
+    ,
+    {
+      # Dedicated subnets for ci.jenkins.io (controller and agents)
+      name = "public-vnet-ci_jenkins_io_controller"
+      address_prefixes = [
+        "10.245.4.0/24", # 10.245.4.1 - 10.245.4.254
+        "fd00:db8:deca::/64",
+      ]
+      service_endpoints                             = []
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = true
+      private_endpoint_network_policies             = "Enabled"
+    }
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
+    "${module.private_vnet.vnet_name}"            = module.private_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}"          = module.public_db_vnet.vnet_id,
+    "${module.public_sponsorship_vnet.vnet_name}" = module.public_sponsorship_vnet.vnet_id,
   }
 }
 
@@ -159,9 +183,70 @@ module "private_vnet" {
   peered_vnets = {
     "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}"                       = module.public_db_vnet.vnet_id,
+    "${module.public_sponsorship_vnet.vnet_name}"              = module.public_sponsorship_vnet.vnet_id,
     "${module.cert_ci_jenkins_io_vnet.vnet_name}"              = module.cert_ci_jenkins_io_vnet.vnet_id
     "${module.trusted_ci_jenkins_io_vnet.vnet_name}"           = module.trusted_ci_jenkins_io_vnet.vnet_id
     "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
+  }
+}
+
+module "public_sponsorship_vnet" {
+  source = "./.shared-tools/terraform/modules/azure-full-vnet"
+
+  providers = {
+    azurerm = azurerm.jenkins-sponsorship
+  }
+
+  base_name          = "public-jenkins-sponsorship"
+  tags               = local.default_tags
+  location           = var.location
+  vnet_address_space = ["10.200.0.0/14"]
+  subnets = [
+    {
+      name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
+      address_prefixes                              = ["10.200.2.0/24"] # 10.200.2.1 - 10.200.2.254
+      service_endpoints                             = []
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = false
+      private_endpoint_network_policies             = "Disabled"
+    },
+    {
+      name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"
+      address_prefixes                              = ["10.200.3.0/24"] # 10.200.3.1 - 10.200.3.254
+      service_endpoints                             = []
+      private_link_service_network_policies_enabled = true
+      private_endpoint_network_policies             = "Enabled"
+      delegations = {
+        "aci" = {
+          service_delegations = [{
+            name    = "Microsoft.ContainerInstance/containerGroups"
+            actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+          }]
+        }
+      }
+    },
+    {
+      name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"
+      address_prefixes                              = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
+      service_endpoints                             = []
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = true
+      private_endpoint_network_policies             = "Disabled"
+    },
+    {
+      name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"
+      address_prefixes                              = ["10.201.0.0/24"] # 10.201.0.0 - 10.201.0.254
+      service_endpoints                             = []
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = false
+      private_endpoint_network_policies             = "Enabled"
+    },
+  ]
+
+  peered_vnets = {
+    "${module.private_vnet.vnet_name}"                         = module.private_vnet.vnet_id,
+    "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id,
+    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id,
   }
 }
 
@@ -333,8 +418,9 @@ module "infra_ci_jenkins_io_sponsorship_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id
-    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
+    "${module.public_sponsorship_vnet.vnet_name}" = module.public_sponsorship_vnet.vnet_id
+    "${module.private_vnet.vnet_name}"            = module.private_vnet.vnet_id
+    "${module.public_db_vnet.vnet_name}"          = module.public_db_vnet.vnet_id,
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4620 and https://github.com/jenkins-infra/helpdesk/issues/4619.

Required by https://github.com/jenkins-infra/azure/pull/975

This PR is a partial revert of #349 with the following changes:

- It only has the "sponsored subscription" related resources.
- The NAT gateway for ci.jenkins.io only has 2 IPs (instead of 4 previously)
- Bugfix on the gateway: it now has an explicit dependency to the module which creates the vnet RG
- Merged outputs for ci.jenkins.io and the associated cijenkinsio-agents-1 cluster since they now have the same set of outbound IPs
