### PR TITLE
feat(vnets) add `Microsoft.Storage` service endpoints for ci.jenkins.io subnets

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -180,7 +180,7 @@ module "public_sponsorship_vnet" {
     {
       name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
       address_prefixes                              = ["10.200.2.0/24"] # 10.200.2.1 - 10.200.2.254
-      service_endpoints                             = []
+      service_endpoints                             = ["Microsoft.Storage"]
       delegations                                   = {}
       private_link_service_network_policies_enabled = false
       private_endpoint_network_policies             = "Disabled"
@@ -188,7 +188,7 @@ module "public_sponsorship_vnet" {
     {
       name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_controller"
       address_prefixes                              = ["10.200.1.0/24"] # 10.200.1.1 - 10.200.1.254
-      service_endpoints                             = []
+      service_endpoints                             = ["Microsoft.Storage"]
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Disabled"
@@ -196,7 +196,7 @@ module "public_sponsorship_vnet" {
     {
       name                                          = "public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes"
       address_prefixes                              = ["10.201.0.0/24"] # 10.201.0.0 - 10.201.0.254
-      service_endpoints                             = []
+      service_endpoints                             = ["Microsoft.Storage"]
       delegations                                   = {}
       private_link_service_network_policies_enabled = false
       private_endpoint_network_policies             = "Enabled"


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/4619

Because https://github.com/jenkins-infra/azure/pull/985 failed to deploy with the following error:

```
09:17:39  │ Message: "Validation of network acls failure: SubnetsHaveNoServiceEndpointsConfigured:Subnets public-jenkins-sponsorship-vnet-ci_jenkins_io_controller, public-jenkins-sponsorship-vnet-ci_jenkins_io_agents, public-jenkins-sponsorship-vnet-ci_jenkins_io_kubernetes of virtual network /subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/public-jenkins-sponsorship/providers/Microsoft.Network/virtualNetworks/public-jenkins-sponsorship-vnet do not have ServiceEndpoints for Microsoft.Storage resources configured. Add Microsoft.Storage to subnet's ServiceEndpoints collection before trying to ACL Microsoft.Storage resources to these subnets.."
```