### PR TITLE
fix(vnets) add missing peering

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -162,6 +162,7 @@ module "private_vnet" {
     "${module.cert_ci_jenkins_io_vnet.vnet_name}"              = module.cert_ci_jenkins_io_vnet.vnet_id
     "${module.trusted_ci_jenkins_io_vnet.vnet_name}"           = module.trusted_ci_jenkins_io_vnet.vnet_id
     "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
+    "${module.private_sponsorship_vnet.vnet_name}"             = module.private_sponsorship_vnet.vnet_id
   }
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2797439659

Fixup of https://github.com/jenkins-infra/azure-net/pull/360

The Azure UI shows the following error in the `private-sponsored-vnet` "Peerings" section:

<img width="983" alt="Capture d’écran 2025-04-13 à 17 08 08" src="https://github.com/user-attachments/assets/a408f414-7318-4052-b2f6-9cd52746645e" />

Syncing has no effect: a popup appears explaining that the counterpart network `private-vnet` does not have any peering enabled to `private-sponsored-vnet`.

This PR aims at fixing this missing element.