### PR TITLE
feat(vnets) add peering between infra.ci-agents and privatek8s-sponsorship

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -223,9 +223,11 @@ module "private_sponsorship_vnet" {
     }
   ]
 
-  # only peer with privatek8s
   peered_vnets = {
+    # Accesses through VPN and privatek8s cluster
     "${module.private_vnet.vnet_name}" = module.private_vnet.vnet_id,
+    # Accesses through the infra.ci agents private vnet
+    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id,
   }
 }
 


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/4250

This PR adds a missing peering to allow infra.ci agents to reach the `privatek8s_sponsorship` AKS control plane for management (for both terraform and helmfile).