### PR TITLE
chore(outputs) export missing privatek8s-sponsorship network infos

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,12 @@ resource "local_file" "jenkins_infra_data_report" {
       "outbound_ips" = concat(split(",", module.infra_ci_outbound_sponsorship.public_ip_list), split(",", module.privatek8s_outbound.public_ip_list)),
     },
     "privatek8s.jenkins.io" = {
-      "outbound_ips" = split(",", module.privatek8s_outbound.public_ip_list),
+      "outbound_ips"      = split(",", module.privatek8s_outbound.public_ip_list),
+      "private_lb_subnet" = "private-vnet-data-tier",
+    },
+    "privatek8s_sponsorship.jenkins.io" = {
+      "outbound_ips"      = split(",", module.privatek8s_outbound_sponsorship.public_ip_list),
+      "private_lb_subnet" = "privatek8s-sponsorship-tier",
     },
     "publick8s.jenkins.io" = {
       "outbound_ips" = split(",", module.publick8s_outbound.public_ip_list),
@@ -30,6 +35,7 @@ resource "local_file" "jenkins_infra_data_report" {
       "cert-ci-jenkins-io-vnet"                = module.cert_ci_jenkins_io_vnet.vnet_address_space,
       "infra-ci-jenkins-io-sponsorship-vnet"   = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_address_space,
       "private-vnet"                           = module.private_vnet.vnet_address_space,
+      "private-sponsorship-vnet"               = module.private_sponsorship_vnet.vnet_address_space,
       "public-db-vnet"                         = module.public_db_vnet.vnet_address_space,
       "public-jenkins-sponsorship-vnet"        = module.public_sponsorship_vnet.vnet_address_space,
       "public-vnet"                            = module.public_vnet.vnet_address_space,

--- a/vnets.tf
+++ b/vnets.tf
@@ -192,9 +192,6 @@ module "private_sponsorship_vnet" {
     },
     {
       # Dedicated subnet for the release nodes of the "privatek8s" AKS cluster resources on sponsorship account
-      ## Important: the "terraform-production" Enterprise Application used by this repo pipeline needs to be able to manage this virtual network.
-      ## See the corresponding role assignment for this vnet added in the (private) terraform-state repo:
-      ## https://github.com/jenkins-infra/terraform-states/blob/17df75c38040c9b1087bade3654391bc5db45ffd/azure/main.tf#L59
       name                                          = "privatek8s-sponsorship-release-tier"
       address_prefixes                              = ["10.242.0.0/25"] # from 10.242.0.0 to 10.242.0.127
       service_endpoints                             = ["Microsoft.KeyVault", "Microsoft.Storage"]

--- a/vnets.tf
+++ b/vnets.tf
@@ -181,8 +181,7 @@ module "private_sponsorship_vnet" {
     {
       # Dedicated subnet for the "privatek8s" AKS cluster resources on sponsorship account
       ## Important: the "terraform-production" Enterprise Application used by this repo pipeline needs to be able to manage this virtual network.
-      ## See the corresponding role assignment for this vnet added in the (private) terraform-state repo:
-      ## https://github.com/jenkins-infra/terraform-states/blob/17df75c38040c9b1087bade3654391bc5db45ffd/azure/main.tf#L59
+      ## Ref. https://github.com/jenkins-infra/terraform-states/blob/e5164afee643d7423a6f90f2bc260b89fc36d9e3/azure/main.tf#L114-L129
       name                                          = "privatek8s-sponsorship-tier"
       address_prefixes                              = ["10.241.0.0/16"]
       service_endpoints                             = ["Microsoft.KeyVault", "Microsoft.Storage"]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250

Required for the private ingress setup of `privatek8s-sponsorship` cluster values.