### PR TITLE
feat(dns-records) migrate github-comment-ops to new privtaek8s-sponsorship cluster

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -249,7 +249,7 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_privatek8s" {
   zone_name           = data.azurerm_dns_zone.jenkinsio.name
   resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
   ttl                 = 300
-  record              = "public.privatek8s.jenkins.io" # A record defined on https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
+  record              = "public.privatek8s-sponsorship.jenkins.io" # A record defined in https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
 
   tags = merge(local.default_tags, {
     purpose = each.value


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516

Blocks https://github.com/jenkins-infra/kubernetes-management/pull/6525