### PR TITLE
 feat(dns) delegate `aws.ci.jenkins.io` to AWS Route53 DNS Zone

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -32,19 +32,14 @@ resource "azurerm_dns_ns_record" "do_jenkins_io" {
   tags = local.default_tags
 }
 
-# Cleanup once the resources are managed in jenkins-infra/azure - https://github.com/jenkins-infra/helpdesk/issues/4630#issuecomment-2846886448
-removed {
-  from = azurerm_dns_zone.child_zones
+# NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them
+resource "azurerm_dns_ns_record" "aws_ci_jenkins_io" {
+  name                = "aws.ci"
+  zone_name           = data.azurerm_dns_zone.jenkinsio.name
+  resource_group_name = data.azurerm_resource_group.proddns_jenkinsio.name
+  ttl                 = 60
 
-  lifecycle {
-    destroy = false
-  }
-}
-# Cleanup once the resources are managed in jenkins-infra/azure - https://github.com/jenkins-infra/helpdesk/issues/4630#issuecomment-2846886448
-removed {
-  from = azurerm_dns_ns_record.child_zone_ns_records
+  records = split(" ", local.aws_route53_nameservers_awscijenkinsio)
 
-  lifecycle {
-    destroy = false
-  }
+  tags = local.default_tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -18,4 +18,8 @@ locals {
     "publick8s_public_ipv6_address" = "2603:1030:408:5::15a" # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
     "ldap_jenkins_io_ipv4_address"  = "20.7.180.148"         # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
   }
+
+  # Tracked by updatecli, easier to use a string split as a list by Terraform
+  # NS records pointing to AWS Route53 name servers to delegate aws.ci.jenkins.io to them
+  aws_route53_nameservers_awscijenkinsio = "ns-1399.awsdns-46.org ns-1646.awsdns-13.co.uk ns-193.awsdns-24.com ns-609.awsdns-12.net"
 }

--- a/updatecli/updatecli.d/aws-dns-ns.yaml
+++ b/updatecli/updatecli.d/aws-dns-ns.yaml
@@ -1,0 +1,50 @@
+name: Track the AWS Route53 DNS Zone Name Servers for delegated zones
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getAwsCiJenkinsIoNameServers:
+    name: Get the Name Servers of the AWS Route 53 aws.ci.jenkins.io DNS zone
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.name_servers
+    transformers:
+      - replacers:
+          - from: '['
+            to: ''
+          - from: ']'
+            to: ''
+
+targets:
+  updateNSRecord:
+    name: Update NS records for aws.ci.jenkins.io
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.aws_route53_nameservers_awscijenkinsio
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: "feat(dns) Update NS records for aws.ci.jenkins.io"
+    spec:
+      description: |
+        A new set of Name Servers for the AWS Route 53 delegated zone for `aws.ci.jenkins.io` were detected in <https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json>.
+        This PR updates the `NS` records with the new detected values.
+      labels:
+        - terraform
+        - dns
+        - aws.ci.jenkins.io


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4688

- AWS DNS zone defined in https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/fed79049d3011a211d0fddc918502cf1a39f5017/ci.jenkins.io.tf#L153-L155
- Updatecli manifest tested locally to update values after reverting #376 . Should fail the check until this PR is merged