### PR TITLE
chore(output) fix infra.ci

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,14 @@ resource "local_file" "jenkins_infra_data_report" {
       "outbound_ips" = split(",", module.public_sponsorship_vnet.public_ip_list),
     },
     "infra.ci.jenkins.io" = {
-      "outbound_ips" = concat(split(",", module.infra_ci_jenkins_io_sponsorship_vnet.public_ip_list), split(",", module.private_sponsorship_vnet.public_ip_list)),
+      "outbound_ips" = concat(
+        # Controller
+        split(",", module.private_sponsorship_vnet.public_ip_list),
+        # VM agents
+        split(",", module.infra_ci_jenkins_io_sponsorship_vnet.public_ip_list),
+        # Container agents
+        split(",", module.infra_ci_jenkins_io_vnet.public_ip_list),
+      ),
     },
     "privatek8s_sponsorship.jenkins.io" = {
       "outbound_ips"      = split(",", module.private_sponsorship_vnet.public_ip_list),
@@ -18,9 +25,6 @@ resource "local_file" "jenkins_infra_data_report" {
     },
     "publick8s.jenkins.io" = {
       "outbound_ips" = split(",", module.public_vnet.public_ip_list),
-    },
-    "infracijenkinsioagents2.jenkins.io" = {
-      "outbound_ips" = split(",", module.infra_ci_jenkins_io_vnet.public_ip_list),
     },
     "private.vpn.jenkins.io" = {
       # VPN VM uses its public IP as outbound method (default Azure behavior) instead of the outbound NAT gateway


### PR DESCRIPTION
https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/265 is failing with the error:

```
Get "https://efd41748f9c38aab83fa81f34c59b313.gr7.us-east-2.eks.amazonaws.com/apis":
    dial tcp 3.149.71.89:443: i/o timeout
```

Because the AWS Terraform project retrieve outbound IPs of infra.ci through the "infra.ci.jenkins.io" key.

This PR fixes the report to have the cluster outbounds under infra.ci.jenkin.io