### PR TITLE
cleanup(vnets) remove infra.ci and packer networks from the sponsorship subscription

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,9 +10,7 @@ resource "local_file" "jenkins_infra_data_report" {
       "outbound_ips" = concat(
         # Controller
         split(",", module.private_sponsorship_vnet.public_ip_list),
-        # VM agents
-        split(",", module.infra_ci_jenkins_io_sponsorship_vnet.public_ip_list),
-        # Container agents
+        # Agents
         split(",", module.infra_ci_jenkins_io_vnet.public_ip_list),
       ),
     },
@@ -32,14 +30,13 @@ resource "local_file" "jenkins_infra_data_report" {
       "outbound_ips" = [azurerm_public_ip.vpn_public.ip_address],
     },
     "vnets" = {
-      "cert-ci-jenkins-io-vnet"              = module.cert_ci_jenkins_io_vnet.vnet_address_space,
-      "infra-ci-jenkins-io-vnet"             = module.infra_ci_jenkins_io_vnet.vnet_address_space,
-      "infra-ci-jenkins-io-sponsorship-vnet" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_address_space,
-      "private-vnet"                         = module.private_vnet.vnet_address_space,
-      "private-sponsorship-vnet"             = module.private_sponsorship_vnet.vnet_address_space,
-      "public-db-vnet"                       = module.public_db_vnet.vnet_address_space,
-      "public-vnet"                          = module.public_vnet.vnet_address_space,
-      "trusted-ci-jenkins-io-vnet"           = module.trusted_ci_jenkins_io_vnet.vnet_address_space,
+      "cert-ci-jenkins-io-vnet"    = module.cert_ci_jenkins_io_vnet.vnet_address_space,
+      "infra-ci-jenkins-io-vnet"   = module.infra_ci_jenkins_io_vnet.vnet_address_space,
+      "private-vnet"               = module.private_vnet.vnet_address_space,
+      "private-sponsorship-vnet"   = module.private_sponsorship_vnet.vnet_address_space,
+      "public-db-vnet"             = module.public_db_vnet.vnet_address_space,
+      "public-vnet"                = module.public_vnet.vnet_address_space,
+      "trusted-ci-jenkins-io-vnet" = module.trusted_ci_jenkins_io_vnet.vnet_address_space,
     }
   })
   filename = "${path.module}/jenkins-infra-data-reports/azure-net.json"

--- a/vnets.tf
+++ b/vnets.tf
@@ -159,13 +159,12 @@ module "private_vnet" {
   ]
 
   peered_vnets = {
-    "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}"                       = module.public_db_vnet.vnet_id,
-    "${module.cert_ci_jenkins_io_vnet.vnet_name}"              = module.cert_ci_jenkins_io_vnet.vnet_id
-    "${module.trusted_ci_jenkins_io_vnet.vnet_name}"           = module.trusted_ci_jenkins_io_vnet.vnet_id
-    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"             = module.infra_ci_jenkins_io_vnet.vnet_id
-    "${module.private_sponsorship_vnet.vnet_name}"             = module.private_sponsorship_vnet.vnet_id
+    "${module.public_vnet.vnet_name}"                = module.public_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}"             = module.public_db_vnet.vnet_id,
+    "${module.cert_ci_jenkins_io_vnet.vnet_name}"    = module.cert_ci_jenkins_io_vnet.vnet_id
+    "${module.trusted_ci_jenkins_io_vnet.vnet_name}" = module.trusted_ci_jenkins_io_vnet.vnet_id
+    "${module.infra_ci_jenkins_io_vnet.vnet_name}"   = module.infra_ci_jenkins_io_vnet.vnet_id
+    "${module.private_sponsorship_vnet.vnet_name}"   = module.private_sponsorship_vnet.vnet_id
   }
 }
 
@@ -224,11 +223,8 @@ module "private_sponsorship_vnet" {
   ]
 
   peered_vnets = {
-    # Accesses through VPN and infra.ci agents
-    "${module.private_vnet.vnet_name}" = module.private_vnet.vnet_id,
-    # Accesses through the infra.ci agents private vnet
-    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"             = module.infra_ci_jenkins_io_vnet.vnet_id
+    "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id,
+    "${module.infra_ci_jenkins_io_vnet.vnet_name}" = module.infra_ci_jenkins_io_vnet.vnet_id
   }
 }
 
@@ -343,51 +339,9 @@ module "infra_ci_jenkins_io_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"                         = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}"                       = module.public_db_vnet.vnet_id,
-    "${module.private_sponsorship_vnet.vnet_name}"             = module.private_sponsorship_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
-  }
-}
-
-module "infra_ci_jenkins_io_sponsorship_vnet" {
-  source = "./.shared-tools/terraform/modules/azure-full-vnet"
-
-  providers = {
-    azurerm = azurerm.jenkins-sponsorship
-  }
-
-  base_name          = "infra-ci-jenkins-io-sponsorship"
-  gateway_name       = "infra-ci-outbound-sponsorship"
-  outbound_ip_count  = 2
-  tags               = local.default_tags
-  location           = var.location
-  vnet_address_space = ["10.206.0.0/22"] # 10.206.0.1 - 10.206.3.254
-
-  subnets = [
-    {
-      name                                          = "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-      address_prefixes                              = ["10.206.0.0/24"] # 10.206.0.1 - 10.206.0.254
-      service_endpoints                             = ["Microsoft.KeyVault", "Microsoft.Storage"]
-      delegations                                   = {}
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-    },
-    {
-      name                                          = "infra-ci-jenkins-io-sponsorship-vnet-packer-builds"
-      address_prefixes                              = ["10.206.1.0/24"] # 10.206.1.1 - 10.206.1.254
-      service_endpoints                             = ["Microsoft.KeyVault", "Microsoft.Storage"]
-      delegations                                   = {}
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-    },
-  ]
-
-  peered_vnets = {
     "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}"           = module.public_db_vnet.vnet_id,
     "${module.private_sponsorship_vnet.vnet_name}" = module.private_sponsorship_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}" = module.infra_ci_jenkins_io_vnet.vnet_id
   }
 }
 
@@ -442,9 +396,8 @@ module "public_db_vnet" {
     }
   ]
   peered_vnets = {
-    "${module.infra_ci_jenkins_io_sponsorship_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsorship_vnet.vnet_id
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"             = module.infra_ci_jenkins_io_vnet.vnet_id
-    "${module.public_vnet.vnet_name}"                          = module.public_vnet.vnet_id
-    "${module.private_vnet.vnet_name}"                         = module.private_vnet.vnet_id
+    "${module.infra_ci_jenkins_io_vnet.vnet_name}" = module.infra_ci_jenkins_io_vnet.vnet_id
+    "${module.public_vnet.vnet_name}"              = module.public_vnet.vnet_id
+    "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id
   }
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4692 and https://github.com/jenkins-infra/helpdesk/issues/4701