### PR TITLE
cleanup: remove leftovers of the decommissioned Azure sponsored subscription and the shared terraform 'infra' module

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -13,10 +13,17 @@ locals {
     }
   }
 
+  # TODO: track with updatecli
   public_ips = {
     "publick8s_public_ipv4_address" = "20.7.178.24"          # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
     "publick8s_public_ipv6_address" = "2603:1030:408:5::15a" # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
     "ldap_jenkins_io_ipv4_address"  = "20.7.180.148"         # defined in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+  }
+
+  admin_public_ips = {
+    dduportal = ["89.84.210.161"],
+    smerle33  = ["82.64.5.129"],
+    mwaite    = ["162.142.59.220"],
   }
 
   # Tracked by updatecli, easier to use a string split as a list by Terraform

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,3 @@
 data "azuread_service_principal" "terraform-azure-net-production" {
   display_name = "terraform-azure-net-production"
 }
-
-module "jenkins_infra_shared_data" {
-  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
-}

--- a/vpn.tf
+++ b/vpn.tf
@@ -52,10 +52,10 @@ resource "azurerm_network_interface" "internal" {
 }
 
 resource "azurerm_network_security_rule" "allow_ssh_from_admins_to_vpn" {
-  for_each = module.jenkins_infra_shared_data.admin_public_ips
+  for_each = local.admin_public_ips
 
   name                        = "allow-ssh-from-${each.key}-to-vpn"
-  priority                    = 101 + (index(keys(module.jenkins_infra_shared_data.admin_public_ips), each.key))
+  priority                    = 101 + (index(keys(local.admin_public_ips), each.key))
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4765

Also cleans up the admin public IPs

Note: by stopping the usage of the terraform module, we are switching to an updatecli "automated updates" pattern instead.

----

Updatecli check is expected to fail (diff on a remote, not local branch) but was tested locally with success by commenting out the target's `scmid` attributes