### PR TITLE
feat(vnets) add peering between infra.ci and public to allow access to the private AKS API

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -80,8 +80,9 @@ module "public_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
+    "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}"           = module.public_db_vnet.vnet_id,
+    "${module.infra_ci_jenkins_io_vnet.vnet_name}" = module.infra_ci_jenkins_io_vnet.vnet_id,
   }
 }
 
@@ -278,6 +279,7 @@ module "infra_ci_jenkins_io_vnet" {
   peered_vnets = {
     "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
+    "${module.public_vnet.vnet_name}"    = module.public_vnet.vnet_id,
   }
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4617

The PR https://github.com/jenkins-infra/azure/pull/1191 failed to apply with TCP `i/o timeout` because infra.ci agents cannot reach the private API of the new `publick8s` cluster.

This change adds peering so this problem won't be there anymore. 