### PR TITLE
feat(dns): migrate some services to the new publick8s (see the list below)

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -120,13 +120,18 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_new_publick8s" {
   depends_on = [azurerm_dns_cname_record.jenkinsio_target_public_publick8s]
   # Map of records and corresponding purposes
   for_each = {
-    "accounts"       = "accountapp for Jenkins users"
-    "plugin-health"  = "Plugin Health Scoring application"
-    "wiki"           = "Static Wiki Confluence export"
-    "javadoc"        = "Jenkins Javadoc"
-    "weekly.ci"      = "Jenkins Weekly demo controller"
-    "plugins.origin" = "Plugins website content origin for Fastly CDN"
-    "www.origin"     = "Jenkins website content origin for Fastly CDN"
+    "accounts"            = "accountapp for Jenkins users"
+    "plugin-health"       = "Plugin Health Scoring application"
+    "wiki"                = "Static Wiki Confluence export"
+    "javadoc"             = "Jenkins Javadoc"
+    "weekly.ci"           = "Jenkins Weekly demo controller"
+    "plugins.origin"      = "Plugins website content origin for Fastly CDN"
+    "www.origin"          = "Jenkins website content origin for Fastly CDN"
+    "builds.reports"      = "Public build reports about the private Jenkins controllers of the Jenkins infrastructure"
+    "contributors.origin" = "Jenkins Contributors Spotlight website content origin for Fastly CDN"
+    "docs.origin"         = "Versioned docs of jenkins.io content origin for Fastly CDN"
+    "plugin-site-issues"  = "Plugins website API content origin for Fastly CDN"
+    "stats"               = "New Jenkins Statistics website"
   }
 
   name                = each.key
@@ -143,22 +148,17 @@ resource "azurerm_dns_cname_record" "jenkinsio_target_public_new_publick8s" {
 resource "azurerm_dns_cname_record" "jenkinsio_target_public_publick8s" {
   # Map of records and corresponding purposes
   for_each = {
-    "azure.updates"       = "Update Center hosted on Azure (Apache redirections service)"
-    "builds.reports"      = "Public build reports about the private Jenkins controllers of the Jenkins infrastructure"
-    "contributors.origin" = "Jenkins Contributors Spotlight website content origin for Fastly CDN"
-    "docs.origin"         = "Versioned docs of jenkins.io content origin for Fastly CDN"
-    "fallback.get"        = "Fallback address for mirrorbits" # Note: had a TTL of 10 minutes before, not 1 hour
-    "get"                 = "Jenkins binary distribution via mirrorbits"
-    "incrementals"        = "incrementals publisher to incrementals Maven repository"
-    "mirrors"             = "Jenkins binary distribution via mirrorbits"
-    "mirrors.updates"     = "Update Center hosted on Azure (Mirrorbits redirections service)"
-    "stats"               = "New Jenkins Statistics website"
-    "plugin-site-issues"  = "Plugins website API content origin for Fastly CDN"
-    "rating"              = "Jenkins releases rating service"
-    "reports"             = "Public reports about Jenkins services and components consumed by RPU, plugins website and others"
-    "staging.get"         = "Test instance for get.jenkins.io"
-    "staging.updates"     = "Test instance for updates.jenkins.io"
-    "uplink"              = "Jenkins telemetry service"
+    "azure.updates"   = "Update Center hosted on Azure (Apache redirections service)"
+    "fallback.get"    = "Fallback address for mirrorbits" # Note: had a TTL of 10 minutes before, not 1 hour
+    "get"             = "Jenkins binary distribution via mirrorbits"
+    "incrementals"    = "incrementals publisher to incrementals Maven repository"
+    "mirrors"         = "Jenkins binary distribution via mirrorbits"
+    "mirrors.updates" = "Update Center hosted on Azure (Mirrorbits redirections service)"
+    "rating"          = "Jenkins releases rating service"
+    "reports"         = "Public reports about Jenkins services and components consumed by RPU, plugins website and others"
+    "staging.get"     = "Test instance for get.jenkins.io"
+    "staging.updates" = "Test instance for updates.jenkins.io"
+    "uplink"          = "Jenkins telemetry service"
   }
 
   name                = each.key


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4617
migrate 
- builds.reports
- contributors.origin
- docs.origin
- plugins-sites-issues
- stats
 
to the new publick8s