### PR TITLE
feat(dns): migrate updates and get for publick8s

### DIFF
--- a/dns-records.tf
+++ b/dns-records.tf
@@ -117,7 +117,6 @@ resource "azurerm_dns_a_record" "aws_updates_jenkins_io" {
 ### CNAME records
 # CNAME records targeting the public-nginx on publick8s cluster
 resource "azurerm_dns_cname_record" "jenkinsio_target_public_new_publick8s" {
-  depends_on = [azurerm_dns_cname_record.jenkinsio_target_public_publick8s]
   # Map of records and corresponding purposes
   for_each = {
     "accounts"            = "accountapp for Jenkins users"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4617

last step migration to the new publick8s for updates, get and incrementals

	"azure.updates"       = "Update Center hosted on Azure (Apache redirections service)"
    "fallback.get"        = "Fallback address for mirrorbits" # Note: had a TTL of 10 minutes before, not 1 hour
    "get"                 = "Jenkins binary distribution via mirrorbits"
    "incrementals"        = "incrementals publisher to incrementals Maven repository"
    "mirrors"             = "Jenkins binary distribution via mirrorbits"
    "mirrors.updates"     = "Update Center hosted on Azure (Mirrorbits redirections service)"