### PR TITLE
feat(modules/azure-full-vnet) ensure default outbound method is always disabled (subnets are privates by default)

### DIFF
--- a/modules/azure-full-vnet/main.tf
+++ b/modules/azure-full-vnet/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "vnet_subnets" {
   service_endpoints                             = each.value.service_endpoints
   private_link_service_network_policies_enabled = try(each.value.private_link_service_network_policies_enabled, true)
   private_endpoint_network_policies             = try(each.value.private_endpoint_network_policies, "Enabled")
-  default_outbound_access_enabled               = try(each.value.use_default_outbound_access, false)
+  default_outbound_access_enabled               = false
 
   dynamic "delegation" {
     for_each = each.value.delegations

--- a/modules/azure-full-vnet/variables.tf
+++ b/modules/azure-full-vnet/variables.tf
@@ -37,7 +37,6 @@ variable "subnets" {
     service_endpoints                             = list(string),
     private_endpoint_network_policies             = string,
     private_link_service_network_policies_enabled = bool,
-    use_default_outbound_access                   = bool,
     delegations = map(object({
       service_delegations = set(object({
         name    = string

--- a/vnets.tf
+++ b/vnets.tf
@@ -64,7 +64,6 @@ module "public_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = false # Required to define Azure PLS
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
   ]
 
@@ -96,7 +95,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       # Dedicated subnet for machine to machine private communications
@@ -106,7 +104,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       # Dedicated subnet for the "privatek8s" AKS cluster resources
@@ -118,7 +115,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       # Dedicated subnet for the release nodes of the "privatek8s" AKS cluster resources
@@ -128,7 +124,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       # Dedicated subnet for the release nodes of the "privatek8s" for the controller infraci AKS cluster resources
@@ -138,7 +133,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       # Dedicated subnet for the private nodes of the "privatek8s" for the controller releaseci AKS cluster resources
@@ -148,7 +142,6 @@ module "private_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     }
   ]
 
@@ -177,7 +170,6 @@ module "trusted_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       name                                          = "trusted-ci-jenkins-io-vnet-ephemeral-agents"
@@ -186,7 +178,6 @@ module "trusted_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       name                                          = "trusted-ci-jenkins-io-vnet-permanent-agents"
@@ -195,7 +186,6 @@ module "trusted_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Disabled"
-      use_default_outbound_access                   = false
     },
   ]
 
@@ -221,7 +211,6 @@ module "cert_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       name                                          = "cert-ci-jenkins-io-vnet-ephemeral-agents"
@@ -230,7 +219,6 @@ module "cert_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
   ]
 
@@ -257,7 +245,6 @@ module "infra_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       name                                          = "infra-ci-jenkins-io-vnet-packer-builds"
@@ -266,7 +253,6 @@ module "infra_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
     {
       name                                          = "infra-ci-jenkins-io-vnet-kubernetes-agents"
@@ -275,7 +261,6 @@ module "infra_ci_jenkins_io_vnet" {
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = false
     },
   ]
 
@@ -305,7 +290,6 @@ module "public_db_vnet" {
       service_endpoints                             = [],
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled"
-      use_default_outbound_access                   = true
       delegations = {
         "pgsql" = {
           service_delegations = [{
@@ -325,7 +309,6 @@ module "public_db_vnet" {
       service_endpoints                             = [],
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Enabled",
-      use_default_outbound_access                   = true
       delegations = {
         "mysql" = {
           service_delegations = [{


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4616

Following up #451, this PR sets the 2 last remaining subnets (delegated to our DBs) to "private" (e.g. disabling the "outbound default method").