### PR TITLE
chore(updatecli): add a manifest to track private.vpn.jenkins.io VM source image reference

### DIFF
--- a/updatecli/updatecli.d/vpn-vm-image-reference.yaml
+++ b/updatecli/updatecli.d/vpn-vm-image-reference.yaml
@@ -1,0 +1,40 @@
+name: Update private.vpn.jenkins.io VM image reference
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestImage:
+    name: Get latest Ubuntu VM image from Canonical
+    kind: shell
+    spec:
+      command: |
+        az vm image list --all --publisher="Canonical" --sku="22_04-lts-gen2" --offer="0001-com-ubuntu-server-jammy" \
+        | jq -r '.[].version' | sort -u | tail -1
+
+targets:
+  updateVpnImageReference:
+    name: Update private VPN VM source image reference
+    kind: hcl
+    spec:
+      file: vpn.tf
+      path: resource.azurerm_linux_virtual_machine.vpn.source_image_reference.version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump private.vpn.jenkins.io VM source image reference to {{ source "getLatestImage" }}
+    spec:
+      labels:
+        - vpn

--- a/vpn.tf
+++ b/vpn.tf
@@ -153,8 +153,6 @@ resource "azurerm_linux_virtual_machine" "vpn" {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-lts-gen2"
-    // TODO: use fixed version + updatecli manifest if it recreates the VM
-    # az vm image list --all --publisher="Canonical" --sku="22_04-lts-gen2" --offer="0001-com-ubuntu-server-jammy"
     version = "22.04.202211160"
   }
 


### PR DESCRIPTION
This change tracks private.vpn.jenkins.io VM image reference, keeping an Ubuntu 22.04 release line for now.

(Late) follow-up of:
- https://github.com/jenkins-infra/azure-net/pull/10

#### Testing done

```bash
$ updatecli diff --config ./updatecli/updatecli.d/vpn-vm-image-reference.yaml --values ./updatecli/values.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/vpn-vm-image-reference.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


####################################################
# UPDATE PRIVATE.VPN.JENKINS.IO VM IMAGE REFERENCE #
####################################################

Pipeline ID     : 0374c8d94c502a9994883fad70dd245f32c07a2e98b03356b264888203372997
Dry Run         : enabled

source: getLatestImage
----------------------

The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/82e2db81ecf4e1cd220f5d91f161b6f78b70786b919804de1705d2a71296050f.sh" ran successfully with the following output:
----
22.04.202601310
----
✔ shell command executed successfully

target: updateVpnImageReference
-------------------------------

Repository      : github.com/jenkins-infra/azure-net@main

⚠ - changes detected:
        path "resource.azurerm_linux_virtual_machine.vpn.source_image_reference.version" updated from "22.04.202211160" to "22.04.202601310" in file "vpn.tf"


ACTIONS
========

---
Pipeline Name   : Update private.vpn.jenkins.io VM image reference
Pipeline ID     : 0374c8d94c502a9994883fad70dd245f32c07a2e98b03356b264888203372997
Dry run         : true
Repository      : github.com/jenkins-infra/azure-net@main
Action          : Bump private.vpn.jenkins.io VM source image reference to 22.04.202601310
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Update private.vpn.jenkins.io VM image reference:
        Source:
                ✔ [getLatestImage] Get latest Ubuntu VM image from Canonical
        Target:
                ⚠ [updateVpnImageReference] Update private VPN VM source image reference
                      * Repository: https://github.com/jenkins-infra/azure-net.git (branch: main)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
 ```