### PR TITLE
cleanup: remove `infra-ci-jenkins-io` vnet

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,6 @@ resource "local_file" "jenkins_infra_data_report" {
         # Controller
         split(",", module.private_vnet.public_ip_list),
         # Agents
-        split(",", module.infra_ci_jenkins_io_vnet.public_ip_list),
         split(",", module.infra_ci_jenkins_io_sponsored_vnet.public_ip_list),
       ),
     },
@@ -36,7 +35,6 @@ resource "local_file" "jenkins_infra_data_report" {
     "vnets" = {
       "cert-ci-jenkins-io-sponsored-vnet"    = module.cert_ci_jenkins_io_sponsored_vnet.vnet_address_space,
       "cert-ci-jenkins-io-vnet"              = module.cert_ci_jenkins_io_vnet.vnet_address_space,
-      "infra-ci-jenkins-io-vnet"             = module.infra_ci_jenkins_io_vnet.vnet_address_space,
       "infra-ci-jenkins-io-sponsored-vnet"   = module.infra_ci_jenkins_io_sponsored_vnet.vnet_address_space,
       "private-vnet"                         = module.private_vnet.vnet_address_space,
       "public-db-vnet"                       = module.public_db_vnet.vnet_address_space,

--- a/vnets.tf
+++ b/vnets.tf
@@ -71,7 +71,6 @@ module "public_vnet" {
   peered_vnets = {
     "${module.private_vnet.vnet_name}"                       = module.private_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}"                     = module.public_db_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"           = module.infra_ci_jenkins_io_vnet.vnet_id,
     "${module.infra_ci_jenkins_io_sponsored_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsored_vnet.vnet_id,
   }
 }
@@ -152,7 +151,6 @@ module "private_vnet" {
     "${module.public_db_vnet.vnet_name}"                       = module.public_db_vnet.vnet_id,
     "${module.cert_ci_jenkins_io_vnet.vnet_name}"              = module.cert_ci_jenkins_io_vnet.vnet_id,
     "${module.trusted_ci_jenkins_io_vnet.vnet_name}"           = module.trusted_ci_jenkins_io_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"             = module.infra_ci_jenkins_io_vnet.vnet_id,
     "${module.infra_ci_jenkins_io_sponsored_vnet.vnet_name}"   = module.infra_ci_jenkins_io_sponsored_vnet.vnet_id,
     "${module.cert_ci_jenkins_io_sponsored_vnet.vnet_name}"    = module.cert_ci_jenkins_io_sponsored_vnet.vnet_id,
     "${module.trusted_ci_jenkins_io_sponsored_vnet.vnet_name}" = module.trusted_ci_jenkins_io_sponsored_vnet.vnet_id,
@@ -294,36 +292,6 @@ module "cert_ci_jenkins_io_sponsored_vnet" {
   }
 }
 
-module "infra_ci_jenkins_io_vnet" {
-  source = "./modules/azure-full-vnet"
-
-  base_name          = "infra-ci-jenkins-io"
-  gateway_name       = "infra-ci-jenkins-io-outbound"
-  outbound_ip_count  = 2
-  tags               = local.default_tags
-  location           = var.location
-  vnet_address_space = ["10.5.0.0/22"] # 10.5.0.1 - 10.5.3.254
-
-  subnets = [
-    {
-      name                                          = "infra-ci-jenkins-io-vnet-kubernetes-agents"
-      address_prefixes                              = ["10.5.2.0/24"] # 10.5.2.0 - 10.5.2.254
-      service_endpoints                             = ["Microsoft.KeyVault", "Microsoft.Storage"]
-      delegations                                   = {}
-      private_link_service_network_policies_enabled = true
-      private_endpoint_network_policies             = "Enabled"
-    },
-  ]
-
-  peered_vnets = {
-    "${module.private_vnet.vnet_name}"                       = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}"                     = module.public_db_vnet.vnet_id,
-    "${module.public_vnet.vnet_name}"                        = module.public_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_sponsored_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsored_vnet.vnet_id,
-  }
-}
-
-
 module "infra_ci_jenkins_io_sponsored_vnet" {
   source = "./modules/azure-full-vnet"
 
@@ -386,7 +354,6 @@ module "infra_ci_jenkins_io_sponsored_vnet" {
     "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id,
     "${module.public_db_vnet.vnet_name}"           = module.public_db_vnet.vnet_id,
     "${module.public_vnet.vnet_name}"              = module.public_vnet.vnet_id,
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}" = module.infra_ci_jenkins_io_vnet.vnet_id,
   }
 }
 
@@ -441,7 +408,6 @@ module "public_db_vnet" {
     }
   ]
   peered_vnets = {
-    "${module.infra_ci_jenkins_io_vnet.vnet_name}"           = module.infra_ci_jenkins_io_vnet.vnet_id
     "${module.infra_ci_jenkins_io_sponsored_vnet.vnet_name}" = module.infra_ci_jenkins_io_sponsored_vnet.vnet_id,
     "${module.public_vnet.vnet_name}"                        = module.public_vnet.vnet_id
     "${module.private_vnet.vnet_name}"                       = module.private_vnet.vnet_id


### PR DESCRIPTION
This change removes this vnet and related peerings as there isn't any resource in this vnet anymore: all agents have been switched to infra-ci-jenkins-io-sponsored, and infra.ci controller is not in this vnet.

Follow-up of:
- https://github.com/jenkins-infra/azure/pull/1382

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5042
- https://github.com/jenkins-infra/helpdesk/issues/5043
- https://github.com/jenkins-infra/helpdesk/issues/5044