### PR TITLE
feat(vnets) trusted.ci.jenkins.io: new subnet for "commons" resources and ensure all subnet are /24.

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -209,7 +209,7 @@ module "trusted_ci_jenkins_io_sponsored_vnet" {
   gateway_name       = "trusted-outbound"
   tags               = local.default_tags
   location           = var.location
-  vnet_address_space = ["10.252.16.0/23"] # 10.252.16.0 - 10.252.17.255
+  vnet_address_space = ["10.252.16.0/22"] # 10.252.16.0 - 10.252.19.254
   subnets = [
     {
       name                                          = "trusted-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
@@ -221,12 +221,21 @@ module "trusted_ci_jenkins_io_sponsored_vnet" {
     },
     {
       name                                          = "trusted-ci-jenkins-io-sponsored-vnet-permanent-agents"
-      address_prefixes                              = ["10.252.17.0/25"] # 10.252.17.0 - 10.252.17.127
+      address_prefixes                              = ["10.252.17.0/24"] # 10.252.17.0 - 10.252.17.127
       service_endpoints                             = ["Microsoft.Storage"]
       delegations                                   = {}
       private_link_service_network_policies_enabled = true
       private_endpoint_network_policies             = "Disabled"
     },
+    {
+      name                                          = "trusted-ci-jenkins-io-sponsored-vnet-commons"
+      address_prefixes                              = ["10.252.18.0/24"] # 10.252.18.0 - 10.252.18.127
+      service_endpoints                             = ["Microsoft.Storage"]
+      delegations                                   = {}
+      private_link_service_network_policies_enabled = true
+      private_endpoint_network_policies             = "Disabled"
+    },
+    // We have a /24 left for controller
   ]
 
   peered_vnets = {
@@ -351,9 +360,9 @@ module "infra_ci_jenkins_io_sponsored_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"             = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}"           = module.public_db_vnet.vnet_id,
-    "${module.public_vnet.vnet_name}"              = module.public_vnet.vnet_id,
+    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
+    "${module.public_vnet.vnet_name}"    = module.public_vnet.vnet_id,
   }
 }
 


### PR DESCRIPTION
Notes:
- Requires extending the vnet to ensure we can add a /24 for the controller
- The subnet for the permanent agent is extended from /25 to /24 to stay homogeneous (e.g. 3rd digit of the IPv4 is constant on a given subnet)

Ref. https://github.com/jenkins-infra/helpdesk/issues/5070