### PR TITLE
feat(nsg) create an empty NSG for `trusted-ci-jenkins-io-sponsored-vnet` subnets

### DIFF
--- a/nsgs.tf
+++ b/nsgs.tf
@@ -129,3 +129,16 @@ resource "azurerm_network_security_group" "public_apptier" {
     destination_address_prefix = "*"
   }
 }
+
+####################################################################################
+## Network Security Group for trusted.ci.jenkins.io's sponsored virtual network
+## TODO: migrate in the azure-vnet module (opt-in)
+####################################################################################
+resource "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
+  provider = azurerm.jenkins-sponsored
+
+  name                = "trusted-ci-jenkins-io-sponsored-vnet"
+  location            = var.location
+  resource_group_name = module.trusted_ci_jenkins_io_sponsored_vnet.vnet_rg_name
+  tags                = local.default_tags
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

This PR creates a new empty NSG aimed at being used on all subnets of the vnet `trusted-ci-jenkins-io-sponsored-vnet`.

This NSG is NOT associated to any subnet for now (see issue link).