### PR TITLE
feat(modules/azure-full-vnet) allow setting up a default NSG for all subnets of a given virtual netowrk

### DIFF
--- a/modules/azure-full-vnet/main.tf
+++ b/modules/azure-full-vnet/main.tf
@@ -105,3 +105,21 @@ resource "azurerm_subnet_nat_gateway_association" "outbound" {
   subnet_id      = each.value
   nat_gateway_id = azurerm_nat_gateway.outbound[0].id
 }
+
+####################################################################################
+## Default NSG (only if var.set_default_nsg is true)
+####################################################################################
+resource "azurerm_network_security_group" "default_nsg" {
+  count = var.set_default_nsg ? 1 : 0
+
+  name                = azurerm_virtual_network.vnet.name
+  location            = azurerm_virtual_network.vnet.location
+  resource_group_name = azurerm_virtual_network.vnet.resource_group_name
+  tags                = var.tags
+}
+resource "azurerm_subnet_network_security_group_association" "default_nsg" {
+  for_each = var.set_default_nsg ? azurerm_subnet.vnet_subnets : {}
+
+  subnet_id                 = each.value.id
+  network_security_group_id = azurerm_network_security_group.default_nsg[0].id
+}

--- a/modules/azure-full-vnet/outputs.tf
+++ b/modules/azure-full-vnet/outputs.tf
@@ -21,3 +21,8 @@ output "subnets" {
 output "public_ip_list" {
   value = var.gateway_name == "" ? "" : (var.outbound_ip_count == 1 ? azurerm_public_ip.outbound[0].ip_address : join(",", concat([azurerm_public_ip.outbound[0].ip_address], azurerm_public_ip.additional_outbounds.*.ip_address)))
 }
+
+output "default_nsg_name" {
+  // Empty string if no default NSG set up
+  value = var.set_default_nsg ? azurerm_network_security_group.default_nsg[0].name : ""
+}

--- a/modules/azure-full-vnet/variables.tf
+++ b/modules/azure-full-vnet/variables.tf
@@ -70,3 +70,9 @@ variable "outbound_ip_count" {
   description = "Number of outbound IPs to use."
   default     = 1
 }
+
+variable "set_default_nsg" {
+  type        = bool
+  description = "Should we create a Network Security Group with the same name as the virtual network and associated to all of its subnets (defaults to false)?"
+  default     = false
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

This PR introduces a new opt-in feature which defines a default Network Security group (NSG) with the same name and resource group as the virtual network and associated with each of the subnets in this virtual network.

It is controlled by the input variable `set_default_nsg` which defaults to `false` (opt-in).

It also exports the NSG name as an output (which is an empty string if the feature is disabled).

- No changes expected in this PR (ensuring non regression on current infrastructure).
- Tested with a local plan enabling it for trusted.ci sponsored network (but requires to move existing NSG so subsequent distinct PR) - see https://github.com/jenkins-infra/azure-net/pull/519