### PR TITLE
feat(vnets/trusted-ci-jenkins-io-sponsored) setup a default NSG for all subnets of the virtual network (migrating from existing NSG)

### DIFF
--- a/modules/azure-full-vnet/main.tf
+++ b/modules/azure-full-vnet/main.tf
@@ -109,7 +109,7 @@ resource "azurerm_subnet_nat_gateway_association" "outbound" {
 ####################################################################################
 ## Default NSG (only if var.set_default_nsg is true)
 ####################################################################################
-resource "azurerm_network_security_group" "default_nsg" {
+resource "azurerm_network_security_group" "default" {
   count = var.set_default_nsg ? 1 : 0
 
   name                = azurerm_virtual_network.vnet.name
@@ -117,9 +117,9 @@ resource "azurerm_network_security_group" "default_nsg" {
   resource_group_name = azurerm_virtual_network.vnet.resource_group_name
   tags                = var.tags
 }
-resource "azurerm_subnet_network_security_group_association" "default_nsg" {
+resource "azurerm_subnet_network_security_group_association" "default" {
   for_each = var.set_default_nsg ? azurerm_subnet.vnet_subnets : {}
 
   subnet_id                 = each.value.id
-  network_security_group_id = azurerm_network_security_group.default_nsg[0].id
+  network_security_group_id = azurerm_network_security_group.default[0].id
 }

--- a/modules/azure-full-vnet/outputs.tf
+++ b/modules/azure-full-vnet/outputs.tf
@@ -24,5 +24,5 @@ output "public_ip_list" {
 
 output "default_nsg_name" {
   // Empty string if no default NSG set up
-  value = var.set_default_nsg ? azurerm_network_security_group.default_nsg[0].name : ""
+  value = var.set_default_nsg ? azurerm_network_security_group.default[0].name : ""
 }

--- a/nsgs.tf
+++ b/nsgs.tf
@@ -132,5 +132,5 @@ resource "azurerm_network_security_group" "public_apptier" {
 
 moved {
   from = azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet
-  to   = module.trusted_ci_jenkins_io_sponsored_vnet.azurerm_network_security_group.default_nsg[0]
+  to   = module.trusted_ci_jenkins_io_sponsored_vnet.azurerm_network_security_group.default[0]
 }

--- a/nsgs.tf
+++ b/nsgs.tf
@@ -130,15 +130,7 @@ resource "azurerm_network_security_group" "public_apptier" {
   }
 }
 
-####################################################################################
-## Network Security Group for trusted.ci.jenkins.io's sponsored virtual network
-## TODO: migrate in the azure-vnet module (opt-in)
-####################################################################################
-resource "azurerm_network_security_group" "trusted_ci_jenkins_io_sponsored_vnet" {
-  provider = azurerm.jenkins-sponsored
-
-  name                = "trusted-ci-jenkins-io-sponsored-vnet"
-  location            = var.location
-  resource_group_name = module.trusted_ci_jenkins_io_sponsored_vnet.vnet_rg_name
-  tags                = local.default_tags
+moved {
+  from = azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet
+  to   = module.trusted_ci_jenkins_io_sponsored_vnet.azurerm_network_security_group.default_nsg[0]
 }

--- a/vnets.tf
+++ b/vnets.tf
@@ -210,6 +210,7 @@ module "trusted_ci_jenkins_io_sponsored_vnet" {
   tags               = local.default_tags
   location           = var.location
   vnet_address_space = ["10.252.16.0/22"] # 10.252.16.0 - 10.252.19.254
+  set_default_nsg    = true
   subnets = [
     {
       name                                          = "trusted-ci-jenkins-io-sponsored-vnet-ephemeral-agents"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

- Requires https://github.com/jenkins-infra/azure-net/pull/518 to allow the module feature
- This change will override the old NSG used only in the subnet for ephemeral agents without removing it: will need a manual cleanup.
  - Need to announce before merging