### PR TITLE
cleanup(nsg) delete `moved {}` directive

### DIFF
--- a/nsgs.tf
+++ b/nsgs.tf
@@ -129,8 +129,3 @@ resource "azurerm_network_security_group" "public_apptier" {
     destination_address_prefix = "*"
   }
 }
-
-moved {
-  from = azurerm_network_security_group.trusted_ci_jenkins_io_sponsored_vnet
-  to   = module.trusted_ci_jenkins_io_sponsored_vnet.azurerm_network_security_group.default[0]
-}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4260751840

This PR has 2 goals:

- Delete a `moved {}` block introduced in #519 
- Finish the deployment of #519 which failed with the following error, requiring a manual NSG <-> subnet dis-association:

```
16:09:51  │ Error: an association between "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/trusted-ci-jenkins-io-sponsored/providers/Microsoft.Network/virtualNetworks/trusted-ci-jenkins-io-sponsored-vnet/subnets/trusted-ci-jenkins-io-sponsored-vnet-ephemeral-agents" and "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.Network/networkSecurityGroups/trusted.ci.jenkins.io-ephemeralagents" already exists - to be managed via Terraform this association needs to be imported into the State. Please see the resource documentation for "azurerm_subnet_network_security_group_association" for more information
```