### PR TITLE
chore(all VMs) ignore user_data changes

### DIFF
--- a/vpn.tf
+++ b/vpn.tf
@@ -157,4 +157,13 @@ resource "azurerm_linux_virtual_machine" "vpn" {
   }
 
   tags = local.default_tags
+
+  lifecycle {
+    ignore_changes = [
+      # Ignoring user_data in case we make changes to the tpl file (which could lead to destroying VMs inadvertently).
+      user_data,
+      # We don't want to re-create VMs when a new image is specified
+      source_image_reference,
+    ]
+  }
 }


### PR DESCRIPTION
We don't want to risk destroying VMs when an harmless change is pushed to the "common" `cloudinit.tftpl` file in jenkins-infra/shared-tools, but we want to always have an up to date cloud init template (when creating/recreating a VM) to benefit from latest changes.

This PR is a sustainable fix, but we can think of other techniques in the future (updatecli to retrieve the file from shared-tools so a PR would always be opened with a proper Terraform plan for instance)

----

Tested with the code in https://github.com/jenkins-infra/shared-tools/pull/175 which do not specify any change