### PR TITLE
fix(vnet) ensure privatek8s_sponsored peerings are bidirectionals

### DIFF
--- a/vnets.tf
+++ b/vnets.tf
@@ -153,6 +153,7 @@ module "private_vnet" {
     "${module.infra_ci_jenkins_io_sponsored_vnet.vnet_name}"   = module.infra_ci_jenkins_io_sponsored_vnet.vnet_id,
     "${module.cert_ci_jenkins_io_sponsored_vnet.vnet_name}"    = module.cert_ci_jenkins_io_sponsored_vnet.vnet_id,
     "${module.trusted_ci_jenkins_io_sponsored_vnet.vnet_name}" = module.trusted_ci_jenkins_io_sponsored_vnet.vnet_id,
+    "${module.privatek8s_sponsored_vnet.vnet_name}"            = module.privatek8s_sponsored_vnet.vnet_id,
   }
 }
 
@@ -325,9 +326,10 @@ module "infra_ci_jenkins_io_sponsored_vnet" {
   ]
 
   peered_vnets = {
-    "${module.private_vnet.vnet_name}"   = module.private_vnet.vnet_id,
-    "${module.public_db_vnet.vnet_name}" = module.public_db_vnet.vnet_id,
-    "${module.public_vnet.vnet_name}"    = module.public_vnet.vnet_id,
+    "${module.private_vnet.vnet_name}"              = module.private_vnet.vnet_id,
+    "${module.public_db_vnet.vnet_name}"            = module.public_db_vnet.vnet_id,
+    "${module.public_vnet.vnet_name}"               = module.public_vnet.vnet_id,
+    "${module.privatek8s_sponsored_vnet.vnet_name}" = module.privatek8s_sponsored_vnet.vnet_id,
   }
 }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/azure-net/pull/534#issuecomment-4479941050

Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952