### PR TITLE
feat(vpn): add jay_jenkins public IP for SSH access to private.vpn

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -24,6 +24,7 @@ locals {
     dduportal = ["86.207.165.174"],
     mwaite    = ["162.142.59.220"],
     hlemeur   = ["82.67.38.76"],
+    jay_jenkins = ["106.51.242.101"],
   }
 
   # Tracked by updatecli, easier to use a string split as a list by Terraform

--- a/locals.tf
+++ b/locals.tf
@@ -21,9 +21,9 @@ locals {
   }
 
   admin_public_ips = {
-    dduportal = ["86.207.165.174"],
-    mwaite    = ["162.142.59.220"],
-    hlemeur   = ["82.67.38.76"],
+    dduportal   = ["86.207.165.174"],
+    mwaite      = ["162.142.59.220"],
+    hlemeur     = ["82.67.38.76"],
     jay_jenkins = ["106.51.242.101"],
   }
 


### PR DESCRIPTION
ref:  
 - jenkins-infra/helpdesk#5148).

Adding my public IP to `admin_public_ips` to allow SSH access to `private.vpn.jenkins.io` for VPN CRL renewal verification 
