### PR TITLE
chore(backends) use clear-text backend config with only the `ARM_CLIENT_SECRET` as credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .tf-prepare/
 .tf-remote-state-enabled
 .terraform
-backend-config
 terraform-plan-output.txt
 tfplan
 jenkins-infra-data-reports/

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -8,10 +8,7 @@ terraform(
       clientSecretVariable: 'ARM_CLIENT_SECRET',
       tenantIdVariable: 'ARM_TENANT_ID',
     ),
-    file(
-      credentialsId: 'staging-terraform-azure-net-backend-config',
-      variable: 'BACKEND_CONFIG_FILE',
-    ),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-azure-net-backend-config-arm-secret'),
   ],
   productionCredentials: [
     azureServicePrincipal(
@@ -21,10 +18,7 @@ terraform(
       clientSecretVariable: 'ARM_CLIENT_SECRET',
       tenantIdVariable: 'ARM_TENANT_ID',
     ),
-    file(
-      credentialsId: 'production-terraform-azure-net-backend-config',
-      variable: 'BACKEND_CONFIG_FILE',
-    ),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-azure-net-backend-config-arm-secret'),
   ],
   publishReports: ['jenkins-infra-data-reports/azure-net.json'],
 )

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -18,7 +18,7 @@ terraform(
       clientSecretVariable: 'ARM_CLIENT_SECRET',
       tenantIdVariable: 'ARM_TENANT_ID',
     ),
-    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-azure-net-backend-config-arm-secret'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'production-terraform-azure-net-backend-config-arm-secret'),
   ],
   publishReports: ['jenkins-infra-data-reports/azure-net.json'],
 )

--- a/README.adoc
+++ b/README.adoc
@@ -10,22 +10,42 @@
 
 This repository hosts the infrastructure-as-code definition for all the link:https://azure.com/[Azure hosted] resources related to the network for the link:https://www.jenkins.io/projects/infrastructure/[Jenkins Infrastructure Project].
 
+See also https://github.com/jenkins-infra/azure for all non-network related resources.
+
 == Requirements
 
-In order to use this repository to provision the Jenkins infrastructure on Azure, you need:
-
-* An `Azure` account
+* An `Azure` account (with the proper roles and permissions)
 * The requirements (of the shared tools) listed at link:https://github.com/jenkins-infra/shared-tools/tree/main/terraform#requirements[shared-tools/terraform#requirements]
-* The link:https://developer.hashicorp.com/terraform/language/settings/backends/azurerm[Terraform AzureRM Backend Configuration] on a local file named `backend-config`:
-** The content can be retrieved from the outputs of the link:{private_repo_url}[(private) repository {private_repo_name}]
-** This file (`backend-config`) is git-ignored
-
-* The git command line to allow cloning the repository and its submodule link:https://github.com/jenkins-infra/shared-tools[shared-tools]
-** This repository has submodules. Once you cloned the repository, execute the following command to obtain the shared tools:
+* The link:https://github.com/jenkins-infra/shared-tools[shared-tools] common repository as a git submodule should be initialized and up-to-date:
+** On a freshly cloned Terraform repository, execute the following command to obtain the shared tools:
 
 [source,bash]
 ----
 git submodule update --init --recursive
+----
+
+** Otherwise you should update to to the latest `main` branch:
+
+[source,bash]
+----
+cd ./.shared-tools
+git pull origin main
+cd ../
+----
+
+* The Azure Credential Secret value to allow the Terraform AzureRM Backend to access remote Azure storage:
+** Must be specified in the environment variable `TF_BACKEND_ARM_CLIENT_SECRET`
+** The secret value should never be written in clear (not in a text file, not in the terminal). For instance on macOS, store it in your Keychain access and set the variable with `export TF_BACKEND_ARM_CLIENT_SECRET="$(security find-generic-password -a jenkins-tf-azure-backend-arm-secret -w)"`
+
+* Routing to database (private endpoints and private DNSes):
+** VPN access is required with routing to the database subnets set up to your user
+** As there are no public DNS, set up your local `/etc/hosts` (check the `providers.tf` for details)
+
+* If you intend to work with the production, the environment variable `TF_VAR_environment` must be set:
+
+[source,bash]
+----
+export TF_VAR_environment=production
 ----
 
 == HowTo

--- a/backend-configs/production
+++ b/backend-configs/production
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-azure-net-production-OUCBCr"
+storage_account_name = "azurenetproductioucbcr"
+container_name       = "azurenetproductioucbcr"
+client_id            = "db8e883a-102d-4800-ba22-3c3dc4e80d54"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend-configs/staging
+++ b/backend-configs/staging
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-azure-net-staging-5oAErn"
+storage_account_name = "azurenetstaging5oaern"
+container_name       = "azurenetstaging5oaern"
+client_id            = "43c8d81c-4168-4171-a4c0-518e55d04be3"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend.tf
+++ b/backend.tf
@@ -1,4 +1,7 @@
 terraform {
   backend "azurerm" {
+    subscription_id = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+    tenant_id       = "4c45fef2-1ba7-4120-80a0-9e2d03e9c2b6"
+    key             = "terraform.tfstate"
   }
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5169#issuecomment-4622327077