### PR TITLE
chore(Jenkinsfile_updatecli): restore daily cron trigger

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,7 +1,6 @@
-updatecli(action: 'diff')
+final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
 
-if (env.BRANCH_IS_PRIMARY) {
-    // Only trigger a daily check on the principal branch
-    properties([pipelineTriggers([cron('@daily')])])
-    updatecli(action: 'apply')
-}
+updatecli(
+    action: updatecliAction,
+    cronTriggerExpression: env.BRANCH_IS_PRIMARY ? '@daily' : '',
+)


### PR DESCRIPTION
- Fixes the daily cron not firing jenkins-infra/helpdesk#5240.

The separate `properties([pipelineTriggers(...)])` call was immediately undone by `updatecli()`, which re-runs `properties()` without a cron and discards the trigger. Passing `cronTriggerExpression` directly to `updatecli()` fixes it.

Also collapses the duplicate `updatecli()` calls into one: the action is now a ternary on `BRANCH_IS_PRIMARY`, so primary branches no longer run `diff` then `apply`. Same pattern as jenkins-infra/terraform-aws-sponsorship#574.
